### PR TITLE
Add license header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+
+  dependencies {
+    classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
+  }
+}
+
 task wrapper(type: Wrapper) {
   gradleVersion = "2.0"
 }
@@ -6,9 +16,15 @@ repositories {
   mavenCentral()
 }
 
+apply plugin: "license"
 apply plugin: "idea"
 apply plugin: "java"
 apply plugin: "project-report"
+
+license {
+  header rootProject.file('license_header.txt')
+  exclude "src/test/resources/svnserver"
+}
 
 dependencies {
   compile "org.jetbrains:annotations:13.0"

--- a/license_header.txt
+++ b/license_header.txt
@@ -1,0 +1,5 @@
+This file is part of git-as-svn. It is subject to the license terms
+in the LICENSE file found in the top-level directory of this distribution
+and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.

--- a/src/main/java/svnserver/StreamHelper.java
+++ b/src/main/java/svnserver/StreamHelper.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/StringHelper.java
+++ b/src/main/java/svnserver/StringHelper.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/SvnConstants.java
+++ b/src/main/java/svnserver/SvnConstants.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/WikiConstants.java
+++ b/src/main/java/svnserver/WikiConstants.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/auth/ACL.java
+++ b/src/main/java/svnserver/auth/ACL.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.auth;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/auth/AnonymousAuthenticator.java
+++ b/src/main/java/svnserver/auth/AnonymousAuthenticator.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.auth;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/auth/Authenticator.java
+++ b/src/main/java/svnserver/auth/Authenticator.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.auth;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/auth/CramMD5Authenticator.java
+++ b/src/main/java/svnserver/auth/CramMD5Authenticator.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.auth;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/auth/LDAPUserDB.java
+++ b/src/main/java/svnserver/auth/LDAPUserDB.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.auth;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/auth/LocalUserDB.java
+++ b/src/main/java/svnserver/auth/LocalUserDB.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.auth;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/auth/PasswordChecker.java
+++ b/src/main/java/svnserver/auth/PasswordChecker.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.auth;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/auth/PlainAuthenticator.java
+++ b/src/main/java/svnserver/auth/PlainAuthenticator.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.auth;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/auth/User.java
+++ b/src/main/java/svnserver/auth/User.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.auth;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/auth/UserDB.java
+++ b/src/main/java/svnserver/auth/UserDB.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.auth;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/auth/UserWithPassword.java
+++ b/src/main/java/svnserver/auth/UserWithPassword.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.auth;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/config/AccessConfig.java
+++ b/src/main/java/svnserver/config/AccessConfig.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.config;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/config/AclConfig.java
+++ b/src/main/java/svnserver/config/AclConfig.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.config;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/config/Config.java
+++ b/src/main/java/svnserver/config/Config.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.config;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/config/GitRepositoryConfig.java
+++ b/src/main/java/svnserver/config/GitRepositoryConfig.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.config;
 
 import org.eclipse.jgit.internal.storage.file.FileRepository;

--- a/src/main/java/svnserver/config/GroupConfig.java
+++ b/src/main/java/svnserver/config/GroupConfig.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.config;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/config/LDAPUserDBConfig.java
+++ b/src/main/java/svnserver/config/LDAPUserDBConfig.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.config;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/config/LocalUserDBConfig.java
+++ b/src/main/java/svnserver/config/LocalUserDBConfig.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.config;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/config/RepositoryConfig.java
+++ b/src/main/java/svnserver/config/RepositoryConfig.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.config;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/config/UserDBConfig.java
+++ b/src/main/java/svnserver/config/UserDBConfig.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.config;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/parser/MessageParser.java
+++ b/src/main/java/svnserver/parser/MessageParser.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.parser;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/parser/SvnServerParser.java
+++ b/src/main/java/svnserver/parser/SvnServerParser.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.parser;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/parser/SvnServerToken.java
+++ b/src/main/java/svnserver/parser/SvnServerToken.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.parser;
 
 import java.io.IOException;

--- a/src/main/java/svnserver/parser/SvnServerWriter.java
+++ b/src/main/java/svnserver/parser/SvnServerWriter.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.parser;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/parser/token/ListBeginToken.java
+++ b/src/main/java/svnserver/parser/token/ListBeginToken.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.parser.token;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/parser/token/ListEndToken.java
+++ b/src/main/java/svnserver/parser/token/ListEndToken.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.parser.token;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/parser/token/NumberToken.java
+++ b/src/main/java/svnserver/parser/token/NumberToken.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.parser.token;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/parser/token/StringToken.java
+++ b/src/main/java/svnserver/parser/token/StringToken.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.parser.token;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/parser/token/TextToken.java
+++ b/src/main/java/svnserver/parser/token/TextToken.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.parser.token;
 
 import svnserver.parser.SvnServerToken;

--- a/src/main/java/svnserver/parser/token/WordToken.java
+++ b/src/main/java/svnserver/parser/token/WordToken.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.parser.token;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/repository/VcsCommitBuilder.java
+++ b/src/main/java/svnserver/repository/VcsCommitBuilder.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/repository/VcsConsumer.java
+++ b/src/main/java/svnserver/repository/VcsConsumer.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/repository/VcsCopyFrom.java
+++ b/src/main/java/svnserver/repository/VcsCopyFrom.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/repository/VcsDeltaConsumer.java
+++ b/src/main/java/svnserver/repository/VcsDeltaConsumer.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/repository/VcsFile.java
+++ b/src/main/java/svnserver/repository/VcsFile.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/repository/VcsFunction.java
+++ b/src/main/java/svnserver/repository/VcsFunction.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository;
 
 import org.tmatesoft.svn.core.SVNException;

--- a/src/main/java/svnserver/repository/VcsLogEntry.java
+++ b/src/main/java/svnserver/repository/VcsLogEntry.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/repository/VcsRepository.java
+++ b/src/main/java/svnserver/repository/VcsRepository.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/repository/VcsRevision.java
+++ b/src/main/java/svnserver/repository/VcsRevision.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/repository/VcsSupplier.java
+++ b/src/main/java/svnserver/repository/VcsSupplier.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository;
 
 import org.tmatesoft.svn.core.SVNException;

--- a/src/main/java/svnserver/repository/git/ChangeHelper.java
+++ b/src/main/java/svnserver/repository/git/ChangeHelper.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/repository/git/GitDeltaConsumer.java
+++ b/src/main/java/svnserver/repository/git/GitDeltaConsumer.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git;
 
 import org.eclipse.jgit.lib.*;

--- a/src/main/java/svnserver/repository/git/GitFile.java
+++ b/src/main/java/svnserver/repository/git/GitFile.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git;
 
 import org.eclipse.jgit.lib.Constants;

--- a/src/main/java/svnserver/repository/git/GitLogEntry.java
+++ b/src/main/java/svnserver/repository/git/GitLogEntry.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/repository/git/GitLogPair.java
+++ b/src/main/java/svnserver/repository/git/GitLogPair.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git;
 
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/svnserver/repository/git/GitObject.java
+++ b/src/main/java/svnserver/repository/git/GitObject.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git;
 
 import org.eclipse.jgit.lib.AnyObjectId;

--- a/src/main/java/svnserver/repository/git/GitPushMode.java
+++ b/src/main/java/svnserver/repository/git/GitPushMode.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git;
 
 import org.eclipse.jgit.lib.ObjectId;

--- a/src/main/java/svnserver/repository/git/GitRepository.java
+++ b/src/main/java/svnserver/repository/git/GitRepository.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git;
 
 import org.eclipse.jgit.diff.DiffEntry;

--- a/src/main/java/svnserver/repository/git/GitRevision.java
+++ b/src/main/java/svnserver/repository/git/GitRevision.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git;
 
 import org.eclipse.jgit.lib.ObjectId;

--- a/src/main/java/svnserver/repository/git/GitTreeEntry.java
+++ b/src/main/java/svnserver/repository/git/GitTreeEntry.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git;
 
 import org.eclipse.jgit.lib.FileMode;

--- a/src/main/java/svnserver/repository/git/GitTreeUpdate.java
+++ b/src/main/java/svnserver/repository/git/GitTreeUpdate.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git;
 
 import org.eclipse.jgit.lib.ObjectId;

--- a/src/main/java/svnserver/repository/git/prop/GitAttributes.java
+++ b/src/main/java/svnserver/repository/git/prop/GitAttributes.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git.prop;
 
 import org.apache.commons.io.FilenameUtils;

--- a/src/main/java/svnserver/repository/git/prop/GitIgnore.java
+++ b/src/main/java/svnserver/repository/git/prop/GitIgnore.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git.prop;
 
 import org.apache.commons.io.FilenameUtils;

--- a/src/main/java/svnserver/repository/git/prop/GitProperty.java
+++ b/src/main/java/svnserver/repository/git/prop/GitProperty.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git.prop;
 
 import org.eclipse.jgit.lib.FileMode;

--- a/src/main/java/svnserver/repository/git/prop/GitPropertyFactory.java
+++ b/src/main/java/svnserver/repository/git/prop/GitPropertyFactory.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git.prop;
 
 import org.atteo.classindex.IndexSubclasses;

--- a/src/main/java/svnserver/repository/git/prop/GitTortoise.java
+++ b/src/main/java/svnserver/repository/git/prop/GitTortoise.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git.prop;
 
 import org.eclipse.jgit.lib.FileMode;

--- a/src/main/java/svnserver/repository/git/prop/PropertyMapping.java
+++ b/src/main/java/svnserver/repository/git/prop/PropertyMapping.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git.prop;
 
 import org.atteo.classindex.ClassIndex;

--- a/src/main/java/svnserver/server/Main.java
+++ b/src/main/java/svnserver/server/Main.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server;
 
 import com.beust.jcommander.JCommander;

--- a/src/main/java/svnserver/server/SessionContext.java
+++ b/src/main/java/svnserver/server/SessionContext.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/SvnServer.java
+++ b/src/main/java/svnserver/server/SvnServer.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/BaseCmd.java
+++ b/src/main/java/svnserver/server/command/BaseCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/CheckPathCmd.java
+++ b/src/main/java/svnserver/server/command/CheckPathCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/CommitCmd.java
+++ b/src/main/java/svnserver/server/command/CommitCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/DeltaCmd.java
+++ b/src/main/java/svnserver/server/command/DeltaCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/DeltaParams.java
+++ b/src/main/java/svnserver/server/command/DeltaParams.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/Depth.java
+++ b/src/main/java/svnserver/server/command/Depth.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/DiffParams.java
+++ b/src/main/java/svnserver/server/command/DiffParams.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/GetDatedRevCmd.java
+++ b/src/main/java/svnserver/server/command/GetDatedRevCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/GetDirCmd.java
+++ b/src/main/java/svnserver/server/command/GetDirCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/GetFileCmd.java
+++ b/src/main/java/svnserver/server/command/GetFileCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/GetIPropsCmd.java
+++ b/src/main/java/svnserver/server/command/GetIPropsCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/GetLatestRevCmd.java
+++ b/src/main/java/svnserver/server/command/GetLatestRevCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/GetLocationSegmentsCmd.java
+++ b/src/main/java/svnserver/server/command/GetLocationSegmentsCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/GetLocationsCmd.java
+++ b/src/main/java/svnserver/server/command/GetLocationsCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/LambdaCmd.java
+++ b/src/main/java/svnserver/server/command/LambdaCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/LogCmd.java
+++ b/src/main/java/svnserver/server/command/LogCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/NoParams.java
+++ b/src/main/java/svnserver/server/command/NoParams.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 /**

--- a/src/main/java/svnserver/server/command/ReparentCmd.java
+++ b/src/main/java/svnserver/server/command/ReparentCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/RevPropCmd.java
+++ b/src/main/java/svnserver/server/command/RevPropCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/RevPropListCmd.java
+++ b/src/main/java/svnserver/server/command/RevPropListCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/StatCmd.java
+++ b/src/main/java/svnserver/server/command/StatCmd.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/StatusParams.java
+++ b/src/main/java/svnserver/server/command/StatusParams.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/SwitchParams.java
+++ b/src/main/java/svnserver/server/command/SwitchParams.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/command/UpdateParams.java
+++ b/src/main/java/svnserver/server/command/UpdateParams.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.command;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/msg/AuthReq.java
+++ b/src/main/java/svnserver/server/msg/AuthReq.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.msg;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/msg/ClientInfo.java
+++ b/src/main/java/svnserver/server/msg/ClientInfo.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.msg;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/step/CheckPermissionStep.java
+++ b/src/main/java/svnserver/server/step/CheckPermissionStep.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.step;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/svnserver/server/step/Step.java
+++ b/src/main/java/svnserver/server/step/Step.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server.step;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/svnserver/SvnTestHelper.java
+++ b/src/test/java/svnserver/SvnTestHelper.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/svnserver/SvnTestServer.java
+++ b/src/test/java/svnserver/SvnTestServer.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver;
 
 import org.eclipse.jgit.api.Git;

--- a/src/test/java/svnserver/TestHelper.java
+++ b/src/test/java/svnserver/TestHelper.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver;
 
 import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryDescription;

--- a/src/test/java/svnserver/ldap/AuthLdapTest.java
+++ b/src/test/java/svnserver/ldap/AuthLdapTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.ldap;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/svnserver/ldap/EmbeddedDirectoryServer.java
+++ b/src/test/java/svnserver/ldap/EmbeddedDirectoryServer.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.ldap;
 
 import org.apache.directory.api.ldap.model.constants.SchemaConstants;

--- a/src/test/java/svnserver/parser/SvnServerParserTest.java
+++ b/src/test/java/svnserver/parser/SvnServerParserTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.parser;
 
 import org.testng.Assert;

--- a/src/test/java/svnserver/replay/ExportSVNEditor.java
+++ b/src/test/java/svnserver/replay/ExportSVNEditor.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.replay;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/svnserver/replay/FilterSVNEditor.java
+++ b/src/test/java/svnserver/replay/FilterSVNEditor.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.replay;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/svnserver/replay/ReplayTest.java
+++ b/src/test/java/svnserver/replay/ReplayTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.replay;
 
 import org.eclipse.jgit.lib.ObjectId;

--- a/src/test/java/svnserver/repository/git/prop/GitAttributesTest.java
+++ b/src/test/java/svnserver/repository/git/prop/GitAttributesTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git.prop;
 
 import org.testng.Assert;

--- a/src/test/java/svnserver/repository/git/prop/GitIgnoreTest.java
+++ b/src/test/java/svnserver/repository/git/prop/GitIgnoreTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git.prop;
 
 import org.eclipse.jgit.lib.FileMode;

--- a/src/test/java/svnserver/repository/git/prop/GitTortoiseTest.java
+++ b/src/test/java/svnserver/repository/git/prop/GitTortoiseTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git.prop;
 
 import org.testng.Assert;

--- a/src/test/java/svnserver/server/DepthTest.java
+++ b/src/test/java/svnserver/server/DepthTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/svnserver/server/StatusCmdTest.java
+++ b/src/test/java/svnserver/server/StatusCmdTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server;
 
 import org.testng.annotations.Test;

--- a/src/test/java/svnserver/server/SvnCheckoutTest.java
+++ b/src/test/java/svnserver/server/SvnCheckoutTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/svnserver/server/SvnCommitTest.java
+++ b/src/test/java/svnserver/server/SvnCommitTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/svnserver/server/SvnFilePropertyTest.java
+++ b/src/test/java/svnserver/server/SvnFilePropertyTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/svnserver/server/SvnGetLocationsTest.java
+++ b/src/test/java/svnserver/server/SvnGetLocationsTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/svnserver/server/SvnLogTest.java
+++ b/src/test/java/svnserver/server/SvnLogTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/svnserver/server/SvnUpdateTest.java
+++ b/src/test/java/svnserver/server/SvnUpdateTest.java
@@ -1,3 +1,10 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.server;
 
 import org.testng.Assert;

--- a/src/test/resources/svnserver/replay/repo/README.txt
+++ b/src/test/resources/svnserver/replay/repo/README.txt
@@ -1,3 +1,11 @@
+====
+    This file is part of git-as-svn. It is subject to the license terms
+    in the LICENSE file found in the top-level directory of this distribution
+    and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+    including this file, may be copied, modified, propagated, or distributed
+    except according to the terms contained in the LICENSE file.
+====
+
 This is a Subversion repository; use the 'svnadmin' and 'svnlook' 
 tools to examine it.  Do not add, delete, or modify files here 
 unless you know how to avoid corrupting the repository.


### PR DESCRIPTION
According to GPL instructions, each source file should have
license header.

Headers on individual files were added automatically by
running `gradle licenseFormat`.

Also, this commit adds license checking to build.gradle.
