### PR TITLE
SetReuseAddress does not work

### DIFF
--- a/src/main/java/svnserver/server/SvnServer.java
+++ b/src/main/java/svnserver/server/SvnServer.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.util.Collection;
 import java.util.HashMap;

--- a/src/main/java/svnserver/server/SvnServer.java
+++ b/src/main/java/svnserver/server/SvnServer.java
@@ -121,9 +121,12 @@ public class SvnServer extends Thread {
 
     repositoryMapping = config.getRepositoryMapping().create(basePath, cacheDb);
     acl = new ACL(config.getAcl());
-    serverSocket = new ServerSocket(config.getPort(), 0, InetAddress.getByName(config.getHost()));
-    serverSocket.setReuseAddress(config.getReuseAddress());
+    /*serverSocket = new ServerSocket(config.getPort(), 0, InetAddress.getByName(config.getHost()));
+    serverSocket.setReuseAddress(config.getReuseAddress());*/
 
+    serverSocket=new ServerSocket();
+    serverSocket.setReuseAddress(config.getReuseAddress());
+    serverSocket.bind(new InetSocketAddress( InetAddress.getByName(config.getHost()),config.getPort()));
     poolExecutor = Executors.newCachedThreadPool();
     log.info("Server bind: {}", serverSocket.getLocalSocketAddress());
   }


### PR DESCRIPTION
SO_ REUSEADDR option must be set before the server port that is bound to be effective.