### PR TITLE
WIP: Show missing objects like forbidden

### DIFF
--- a/src/main/java/svnserver/repository/SvnForbiddenException.java
+++ b/src/main/java/svnserver/repository/SvnForbiddenException.java
@@ -1,0 +1,20 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
+package svnserver.repository;
+
+import java.io.IOException;
+
+/**
+ * Entry forbidden.
+ *
+ * @author Artem V. Navrotskiy <bozaro@users.noreply.github.com>
+ */
+public class SvnForbiddenException extends IOException {
+  public SvnForbiddenException() {
+  }
+}

--- a/src/main/java/svnserver/repository/git/GitRepository.java
+++ b/src/main/java/svnserver/repository/git/GitRepository.java
@@ -432,11 +432,14 @@ public class GitRepository implements VcsRepository {
     GitProperty[] props = directoryPropertyCache.get(treeEntry.getObjectId().getObject());
     if (props == null) {
       final List<GitProperty> propList = new ArrayList<>();
-      for (GitTreeEntry entry : entryProvider.get()) {
-        final GitProperty[] parseProps = parseGitProperty(entry.getFileName(), entry.getObjectId());
-        if (parseProps.length > 0) {
-          propList.addAll(Arrays.asList(parseProps));
+      try {
+        for (GitTreeEntry entry : entryProvider.get()) {
+          final GitProperty[] parseProps = parseGitProperty(entry.getFileName(), entry.getObjectId());
+          if (parseProps.length > 0) {
+            propList.addAll(Arrays.asList(parseProps));
+          }
         }
+      } catch (SvnForbiddenException ignored) {
       }
       if (!propList.isEmpty()) {
         props = propList.toArray(new GitProperty[propList.size()]);
@@ -654,7 +657,7 @@ public class GitRepository implements VcsRepository {
     if (tree.getFileMode().equals(FileMode.GITLINK)) {
       GitObject<RevCommit> linkedCommit = loadLinkedCommit(tree.getObjectId().getObject());
       if (linkedCommit == null) {
-        return null;
+        throw new SvnForbiddenException();
       }
       return new GitObject<>(linkedCommit.getRepo(), linkedCommit.getObject().getTree());
     } else {

--- a/src/test/java/svnserver/repository/git/filter/GitFilterDeny.java
+++ b/src/test/java/svnserver/repository/git/filter/GitFilterDeny.java
@@ -1,0 +1,60 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
+package svnserver.repository.git.filter;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.jetbrains.annotations.NotNull;
+import svnserver.context.LocalContext;
+import svnserver.repository.SvnForbiddenException;
+import svnserver.repository.git.GitObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Get object as is.
+ *
+ * @author Artem V. Navrotskiy <bozaro@users.noreply.github.com>
+ */
+public final class GitFilterDeny implements GitFilter {
+  @NotNull
+  public static final String NAME = "deny";
+
+  public GitFilterDeny(@NotNull LocalContext context) {
+  }
+
+  @NotNull
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @NotNull
+  @Override
+  public String getMd5(@NotNull GitObject<? extends ObjectId> objectId) throws IOException {
+    throw new SvnForbiddenException();
+  }
+
+  @Override
+  public long getSize(@NotNull GitObject<? extends ObjectId> objectId) throws IOException {
+    throw new SvnForbiddenException();
+  }
+
+  @NotNull
+  @Override
+  public InputStream inputStream(@NotNull GitObject<? extends ObjectId> objectId) throws IOException {
+    throw new SvnForbiddenException();
+  }
+
+  @NotNull
+  @Override
+  public OutputStream outputStream(@NotNull OutputStream stream) throws IOException {
+    throw new SvnForbiddenException();
+  }
+}

--- a/src/test/java/svnserver/repository/git/filter/GitFilterDeny.java
+++ b/src/test/java/svnserver/repository/git/filter/GitFilterDeny.java
@@ -9,6 +9,9 @@ package svnserver.repository.git.filter;
 
 import org.eclipse.jgit.lib.ObjectId;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.tmatesoft.svn.core.SVNException;
+import svnserver.auth.User;
 import svnserver.context.LocalContext;
 import svnserver.repository.SvnForbiddenException;
 import svnserver.repository.git.GitObject;
@@ -54,7 +57,7 @@ public final class GitFilterDeny implements GitFilter {
 
   @NotNull
   @Override
-  public OutputStream outputStream(@NotNull OutputStream stream) throws IOException {
+  public OutputStream outputStream(@NotNull OutputStream stream, @Nullable User user) throws IOException, SVNException {
     throw new SvnForbiddenException();
   }
 }


### PR DESCRIPTION
In some case we have no all data for some commits:

 * reference to missing commit in submodule repositories;
 * reference to missing file in external LFS storage.

In this case match better to show this objects like forbidden until object became available.