### PR TITLE
LDAP: Fix connection pool race condition

### DIFF
--- a/config.example
+++ b/config.example
@@ -105,11 +105,11 @@ userDB: !localUsers
 
 # LDAP bind (default - anonymous bind):
 #
-# bind: ldapBindSimple
+# bind: !ldapBindSimple
 #   username: somebody
 #   password: secret
 #
-# bind: ldapBindDn
+# bind: !ldapBindDn
 #   bindDn: cn=somebody,ou=groups,dc=mycompany,dc=com
 #   password: secret
 #
@@ -125,9 +125,3 @@ userDB: !localUsers
 # LDAP attribute, containing user email.
 #
 # emailAttribute: mail
-
-# The search scope. Set to `true` if you wish to search the entire subtree rooted at the
-# userBase entry. The default value of `false` requests a single-level search
-# including only the top level.
-#
-# userSubtree: false

--- a/src/main/java/svnserver/server/SvnServer.java
+++ b/src/main/java/svnserver/server/SvnServer.java
@@ -127,6 +127,11 @@ public class SvnServer extends Thread {
     return serverSocket.getLocalPort();
   }
 
+  @NotNull
+  public SharedContext getContext() {
+    return context;
+  }
+
   @Override
   public void run() {
     log.info("Server is ready on port: {}", serverSocket.getLocalPort());

--- a/src/test/java/svnserver/SvnTestServer.java
+++ b/src/test/java/svnserver/SvnTestServer.java
@@ -220,6 +220,11 @@ public final class SvnTestServer implements SvnTester {
     server.startShutdown();
   }
 
+  @NotNull
+  public SharedContext getContext() {
+    return server.getContext();
+  }
+
   private static class TestRepositoryConfig implements RepositoryMappingConfig {
     @NotNull
     private final Repository repository;

--- a/src/test/java/svnserver/ldap/AuthLdapTest.java
+++ b/src/test/java/svnserver/ldap/AuthLdapTest.java
@@ -8,11 +8,21 @@
 package svnserver.ldap;
 
 import org.jetbrains.annotations.NotNull;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.tmatesoft.svn.core.SVNAuthenticationException;
+import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.auth.BasicAuthenticationManager;
 import org.tmatesoft.svn.core.io.SVNRepository;
 import svnserver.SvnTestServer;
+import svnserver.auth.User;
+import svnserver.auth.UserDB;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * LDAP authentication test.
@@ -23,6 +33,34 @@ public class AuthLdapTest {
   @Test
   public void validUser() throws Throwable {
     checkUser("ldapadmin", "ldapadmin");
+  }
+
+  @Test
+  public void validUserPooled() throws Throwable {
+    try (
+        EmbeddedDirectoryServer ldap = EmbeddedDirectoryServer.create();
+        SvnTestServer server = SvnTestServer.createEmpty(ldap.createUserConfig())
+    ) {
+      final ExecutorService pool = Executors.newFixedThreadPool(10);
+      final AtomicBoolean done = new AtomicBoolean(false);
+      final UserDB userDB = server.getContext().sure(UserDB.class);
+
+      final List<Callable<Void>> tasks = new ArrayList<>();
+      for (int i = 0; i < 1000; ++i) {
+        tasks.add(new SuccessAuth(userDB, done, "ldapadmin", "ldapadmin"));
+        tasks.add(new SuccessAuth(userDB, done, "simple", "simple"));
+        tasks.add(new InvalidAuth(userDB, done, "simple", "hacker"));
+      }
+      try {
+        for (Future<?> future : pool.invokeAll(tasks)) {
+          Assert.assertFalse(done.get());
+          future.get(300, TimeUnit.SECONDS);
+        }
+      } finally {
+        done.set(true);
+        pool.shutdown();
+      }
+    }
   }
 
   @Test(expectedExceptions = SVNAuthenticationException.class)
@@ -43,6 +81,67 @@ public class AuthLdapTest {
       final SVNRepository repo = server.openSvnRepository();
       repo.setAuthenticationManager(new BasicAuthenticationManager(login, password));
       repo.getLatestRevision();
+    }
+  }
+
+  private static class SuccessAuth implements Callable<Void> {
+    @NotNull
+    private final AtomicBoolean done;
+    @NotNull
+    private final UserDB userDB;
+    @NotNull
+    private final String username;
+    @NotNull
+    private final String password;
+
+    public SuccessAuth(@NotNull UserDB userDB, @NotNull AtomicBoolean done, @NotNull String username, @NotNull String password) {
+      this.done = done;
+      this.userDB = userDB;
+      this.username = username;
+      this.password = password;
+    }
+
+    @Override
+    public Void call() throws Exception {
+      if (done.get()) return null;
+      try {
+        final User user = userDB.check(username, password);
+        Assert.assertNotNull(user);
+        Assert.assertEquals(user.getUserName(), username);
+      } catch (IOException | SVNException e) {
+        done.set(false);
+      }
+      return null;
+    }
+  }
+
+  private static class InvalidAuth implements Callable<Void> {
+    @NotNull
+    private final AtomicBoolean done;
+    @NotNull
+    private final UserDB userDB;
+    @NotNull
+    private final String username;
+    @NotNull
+    private final String password;
+
+    public InvalidAuth(@NotNull UserDB userDB, @NotNull AtomicBoolean done, @NotNull String username, @NotNull String password) {
+      this.done = done;
+      this.userDB = userDB;
+      this.username = username;
+      this.password = password;
+    }
+
+    @Override
+    public Void call() throws Exception {
+      if (done.get()) return null;
+      try {
+        final User user = userDB.check(username, password);
+        Assert.assertNull(user);
+      } catch (IOException | SVNException e) {
+        done.set(false);
+      }
+      return null;
     }
   }
 }

--- a/src/test/java/svnserver/ldap/EmbeddedDirectoryServer.java
+++ b/src/test/java/svnserver/ldap/EmbeddedDirectoryServer.java
@@ -114,6 +114,7 @@ public final class EmbeddedDirectoryServer implements AutoCloseable {
     config.setLoginAttribute("uid");
     config.setEmailAttribute("mail");
     config.setNameAttribute("givenName");
+    config.setMaxConnections(3);
     return config;
   }
 }

--- a/src/test/resources/svnserver/ldap/ldap.ldif
+++ b/src/test/resources/svnserver/ldap/ldap.ldif
@@ -57,6 +57,7 @@ sn: User
 cn: Simple User
 uid: simple
 userPassword: simple
+mail: simple@mail.example.com
 objectClass: person
 objectClass: inetOrgPerson
 objectClass: top


### PR DESCRIPTION
LDAP authentication sometimes silently hangs after upgrade from 1.0.11-alpha