### PR TITLE
Add support for GitLab LFS storage layout

### DIFF
--- a/config-gitlab.example
+++ b/config-gitlab.example
@@ -22,8 +22,12 @@ shared:
       forwarded: true
   # Git LFS server
   - !lfs
-    path: lfs
-    token: secret
+    # Secret token for git-lfs-authenticate script
+    # token: secret
+    path: /mnt/storage/lfs-objects
+    saveMeta: false
+    compress: false
+    layout: GitLab
   # GitLab server
   - !gitlab
     url: http://localhost:3000/

--- a/src/main/java/svnserver/ext/gitlfs/config/LfsConfig.java
+++ b/src/main/java/svnserver/ext/gitlfs/config/LfsConfig.java
@@ -10,6 +10,7 @@ package svnserver.ext.gitlfs.config;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.tmatesoft.svn.core.SVNException;
+import svnserver.config.ConfigHelper;
 import svnserver.config.SharedConfig;
 import svnserver.config.serializer.ConfigType;
 import svnserver.context.LocalContext;
@@ -97,7 +98,7 @@ public class LfsConfig implements SharedConfig, LfsStorageFactory {
 
   @NotNull
   public LfsStorage createStorage(@NotNull LocalContext context) {
-    File dataRoot = new File(context.getShared().getBasePath(), path);
+    File dataRoot = ConfigHelper.joinPath(context.getShared().getBasePath(), getPath());
     File metaRoot = isSaveMeta() ? new File(context.sure(GitLocation.class).getFullPath(), "lfs/meta") : null;
     return new LfsLocalStorage(getLayout(), dataRoot, metaRoot, isCompress());
   }

--- a/src/main/java/svnserver/ext/gitlfs/config/LfsConfig.java
+++ b/src/main/java/svnserver/ext/gitlfs/config/LfsConfig.java
@@ -35,8 +35,11 @@ public class LfsConfig implements SharedConfig, LfsStorageFactory {
   @NotNull
   private String pathFormat = "{0}.git";
   private boolean compress = true;
+  private boolean saveMeta = true;
   @Nullable
   private String token;
+  @NotNull
+  private LfsLayout layout = LfsLayout.OneLevel;
 
   @NotNull
   public String getPath() {
@@ -64,6 +67,23 @@ public class LfsConfig implements SharedConfig, LfsStorageFactory {
     this.compress = compress;
   }
 
+  public boolean isSaveMeta() {
+    return saveMeta;
+  }
+
+  public void setSaveMeta(boolean saveMeta) {
+    this.saveMeta = saveMeta;
+  }
+
+  @NotNull
+  public LfsLayout getLayout() {
+    return layout;
+  }
+
+  public void setLayout(@NotNull LfsLayout layout) {
+    this.layout = layout;
+  }
+
   @NotNull
   public static LfsStorage getStorage(@NotNull LocalContext context) throws IOException, SVNException {
     return context.getShared().getOrCreate(LfsStorageFactory.class, LfsConfig::new).createStorage(context);
@@ -78,8 +98,7 @@ public class LfsConfig implements SharedConfig, LfsStorageFactory {
   @NotNull
   public LfsStorage createStorage(@NotNull LocalContext context) {
     File dataRoot = new File(context.getShared().getBasePath(), path);
-    File metaRoot = new File(context.sure(GitLocation.class).getFullPath(), "lfs/meta");
-    return new LfsLocalStorage(dataRoot, metaRoot, isCompress());
+    File metaRoot = isSaveMeta() ? new File(context.sure(GitLocation.class).getFullPath(), "lfs/meta") : null;
+    return new LfsLocalStorage(getLayout(), dataRoot, metaRoot, isCompress());
   }
-
 }

--- a/src/main/java/svnserver/ext/gitlfs/config/LfsLayout.java
+++ b/src/main/java/svnserver/ext/gitlfs/config/LfsLayout.java
@@ -1,0 +1,42 @@
+/**
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
+package svnserver.ext.gitlfs.config;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Git LFS file layout.
+ *
+ * @author Artem V. Navrotskiy <bozaro@users.noreply.github.com>
+ */
+public enum LfsLayout {
+  OneLevel {
+    @NotNull
+    @Override
+    public String getPath(@NotNull String oid) {
+      return oid.substring(0, 2) + "/" + oid;
+    }
+  },
+  TwoLevels {
+    @NotNull
+    @Override
+    public String getPath(@NotNull String oid) {
+      return oid.substring(0, 2) + "/" + oid.substring(2, 4) + "/" + oid;
+    }
+  },
+  GitLab {
+    @NotNull
+    @Override
+    public String getPath(@NotNull String oid) {
+      return oid.substring(0, 2) + "/" + oid.substring(2, 4) + "/" + oid.substring(4);
+    }
+  };
+
+  @NotNull
+  public abstract String getPath(@NotNull String oid);
+}

--- a/src/main/java/svnserver/ext/gitlfs/storage/local/LfsLocalReader.java
+++ b/src/main/java/svnserver/ext/gitlfs/storage/local/LfsLocalReader.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import ru.bozaro.gitlfs.pointer.Constants;
 import ru.bozaro.gitlfs.pointer.Pointer;
+import svnserver.ext.gitlfs.config.LfsLayout;
 import svnserver.ext.gitlfs.storage.LfsReader;
 import svnserver.ext.gitlfs.storage.LfsStorage;
 
@@ -19,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
@@ -36,24 +38,29 @@ public class LfsLocalReader implements LfsReader {
   private final Map<String, String> meta;
 
   @Nullable
-  public static LfsLocalReader create(@NotNull File dataRoot, @NotNull File metaRoot, @NotNull String oid) throws IOException {
-    final File metaPath = LfsLocalStorage.getPath(metaRoot, oid, ".meta");
-    if (metaPath == null || !metaPath.isFile()) {
-      return null;
-    }
+  public static LfsLocalReader create(@NotNull LfsLayout layout, @NotNull File dataRoot, @Nullable File metaRoot, @NotNull String oid) throws IOException {
     final Map<String, String> meta;
-    try (InputStream stream = new FileInputStream(metaPath)) {
-      meta = Pointer.parsePointer(ByteStreams.toByteArray(stream));
-    }
-    if (meta == null) {
-      throw new IOException("Corrupted meta file: " + metaPath.getAbsolutePath());
-    }
-    if (!meta.get(Constants.OID).equals(oid)) {
-      throw new IOException("Corrupted meta file: " + metaPath.getAbsolutePath() + " - unexpected oid:" + meta.get(Constants.OID));
+    if (metaRoot != null) {
+      final File metaPath = LfsLocalStorage.getPath(layout, metaRoot, oid, ".meta");
+      if (metaPath == null || !metaPath.isFile()) {
+        return null;
+      }
+      try (InputStream stream = new FileInputStream(metaPath)) {
+        meta = Pointer.parsePointer(ByteStreams.toByteArray(stream));
+      }
+      if (meta == null) {
+        throw new IOException("Corrupted meta file: " + metaPath.getAbsolutePath());
+      }
+      if (!meta.get(Constants.OID).equals(oid)) {
+        throw new IOException("Corrupted meta file: " + metaPath.getAbsolutePath() + " - unexpected oid:" + meta.get(Constants.OID));
+      }
+    } else {
+      meta = new HashMap<>();
+      meta.put(Constants.OID, oid);
     }
 
-    File dataPath = LfsLocalStorage.getPath(dataRoot, oid, "");
-    File gzipPath = LfsLocalStorage.getPath(dataRoot, oid, ".gz");
+    File dataPath = LfsLocalStorage.getPath(layout, dataRoot, oid, "");
+    File gzipPath = LfsLocalStorage.getPath(layout, dataRoot, oid, ".gz");
     if (dataPath != null && !dataPath.isFile()) {
       dataPath = null;
     }

--- a/src/main/java/svnserver/ext/gitlfs/storage/local/LfsLocalReader.java
+++ b/src/main/java/svnserver/ext/gitlfs/storage/local/LfsLocalReader.java
@@ -40,6 +40,8 @@ public class LfsLocalReader implements LfsReader {
   @Nullable
   public static LfsLocalReader create(@NotNull LfsLayout layout, @NotNull File dataRoot, @Nullable File metaRoot, @NotNull String oid) throws IOException {
     final Map<String, String> meta;
+    File dataPath = LfsLocalStorage.getPath(layout, dataRoot, oid, "");
+    File gzipPath = LfsLocalStorage.getPath(layout, dataRoot, oid, ".gz");
     if (metaRoot != null) {
       final File metaPath = LfsLocalStorage.getPath(layout, metaRoot, oid, ".meta");
       if (metaPath == null || !metaPath.isFile()) {
@@ -55,12 +57,15 @@ public class LfsLocalReader implements LfsReader {
         throw new IOException("Corrupted meta file: " + metaPath.getAbsolutePath() + " - unexpected oid:" + meta.get(Constants.OID));
       }
     } else {
+      if (dataPath == null || !dataPath.isFile()) {
+        return null;
+      }
+      gzipPath = null;
       meta = new HashMap<>();
       meta.put(Constants.OID, oid);
+      meta.put(Constants.SIZE, Long.toString(dataPath.length()));
     }
 
-    File dataPath = LfsLocalStorage.getPath(layout, dataRoot, oid, "");
-    File gzipPath = LfsLocalStorage.getPath(layout, dataRoot, oid, ".gz");
     if (dataPath != null && !dataPath.isFile()) {
       dataPath = null;
     }

--- a/src/main/java/svnserver/ext/gitlfs/storage/local/LfsLocalStorage.java
+++ b/src/main/java/svnserver/ext/gitlfs/storage/local/LfsLocalStorage.java
@@ -9,11 +9,14 @@ package svnserver.ext.gitlfs.storage.local;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import svnserver.auth.User;
 import svnserver.ext.gitlfs.config.LfsLayout;
 import svnserver.ext.gitlfs.storage.LfsReader;
 import svnserver.ext.gitlfs.storage.LfsStorage;
 import svnserver.ext.gitlfs.storage.LfsWriter;
+import svnserver.server.SvnServer;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,6 +27,9 @@ import java.io.IOException;
  * @author Artem V. Navrotskiy <bozaro@users.noreply.github.com>
  */
 public class LfsLocalStorage implements LfsStorage {
+  @NotNull
+  private static final Logger log = LoggerFactory.getLogger(LfsLocalStorage.class);
+
   @NotNull
   public static final String HASH_MD5 = "hash-md5";
   @NotNull
@@ -47,7 +53,10 @@ public class LfsLocalStorage implements LfsStorage {
     this.layout = layout;
     this.dataRoot = dataRoot;
     this.metaRoot = metaRoot;
-    this.compress = compress;
+    this.compress = compress && (metaRoot != null);
+    if (compress && (metaRoot == null)){
+      log.error("Compression not supported for local LFS storage without metadata. Compression is disabled");
+    }
   }
 
   @Nullable
@@ -66,6 +75,8 @@ public class LfsLocalStorage implements LfsStorage {
   static File getPath(@NotNull LfsLayout layout, @NotNull File root, @NotNull String oid, @NotNull String suffix) {
     if (!oid.startsWith(OID_PREFIX)) return null;
     final int offset = OID_PREFIX.length();
-    return new File(root, layout.getPath(oid.substring(offset)) + suffix);
+    File file = new File(root, layout.getPath(oid.substring(offset)) + suffix);
+    log.warn(file.getAbsolutePath());
+    return file;
   }
 }

--- a/src/main/java/svnserver/ext/gitlfs/storage/local/LfsLocalStorage.java
+++ b/src/main/java/svnserver/ext/gitlfs/storage/local/LfsLocalStorage.java
@@ -10,6 +10,7 @@ package svnserver.ext.gitlfs.storage.local;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import svnserver.auth.User;
+import svnserver.ext.gitlfs.config.LfsLayout;
 import svnserver.ext.gitlfs.storage.LfsReader;
 import svnserver.ext.gitlfs.storage.LfsStorage;
 import svnserver.ext.gitlfs.storage.LfsWriter;
@@ -35,12 +36,15 @@ public class LfsLocalStorage implements LfsStorage {
   public static final String META_REAL_NAME = "author-name";
 
   @NotNull
-  private final File dataRoot;
+  private final LfsLayout layout;
   @NotNull
+  private final File dataRoot;
+  @Nullable
   private final File metaRoot;
   private final boolean compress;
 
-  public LfsLocalStorage(@NotNull File dataRoot, @NotNull File metaRoot, boolean compress) {
+  public LfsLocalStorage(@NotNull LfsLayout layout, @NotNull File dataRoot, @Nullable File metaRoot, boolean compress) {
+    this.layout = layout;
     this.dataRoot = dataRoot;
     this.metaRoot = metaRoot;
     this.compress = compress;
@@ -49,19 +53,19 @@ public class LfsLocalStorage implements LfsStorage {
   @Nullable
   @Override
   public LfsReader getReader(@NotNull String oid) throws IOException {
-    return LfsLocalReader.create(dataRoot, metaRoot, oid);
+    return LfsLocalReader.create(layout, dataRoot, metaRoot, oid);
   }
 
   @NotNull
   @Override
   public LfsWriter getWriter(@Nullable User user) throws IOException {
-    return new LfsLocalWriter(dataRoot, metaRoot, compress, user);
+    return new LfsLocalWriter(layout, dataRoot, metaRoot, compress, user);
   }
 
   @Nullable
-  static File getPath(@NotNull File root, @NotNull String oid, @NotNull String suffix) {
+  static File getPath(@NotNull LfsLayout layout, @NotNull File root, @NotNull String oid, @NotNull String suffix) {
     if (!oid.startsWith(OID_PREFIX)) return null;
     final int offset = OID_PREFIX.length();
-    return new File(root, oid.substring(offset, offset + 2) + "/" + oid.substring(offset) + suffix);
+    return new File(root, layout.getPath(oid.substring(offset)) + suffix);
   }
 }

--- a/src/main/java/svnserver/ext/gitlfs/storage/local/LfsLocalWriter.java
+++ b/src/main/java/svnserver/ext/gitlfs/storage/local/LfsLocalWriter.java
@@ -74,7 +74,7 @@ public class LfsLocalWriter extends LfsWriter {
     digestMd5 = HashHelper.md5();
     digestSha = HashHelper.sha256();
     size = 0;
-    if (compress) {
+    if (this.compress) {
       dataStream = new GZIPOutputStream(new FileOutputStream(dataTemp));
     } else {
       dataStream = new FileOutputStream(dataTemp);

--- a/src/main/java/svnserver/repository/git/push/GitPushEmbedded.java
+++ b/src/main/java/svnserver/repository/git/push/GitPushEmbedded.java
@@ -38,11 +38,11 @@ public class GitPushEmbedded implements GitPusher {
   private static final Logger log = LoggerFactory.getLogger(GitPushEmbedded.class);
   @NotNull
   private final SharedContext context;
-  @NotNull
+  @Nullable
   private final String preReceive;
-  @NotNull
+  @Nullable
   private final String postReceive;
-  @NotNull
+  @Nullable
   private final String update;
 
   @FunctionalInterface
@@ -51,7 +51,7 @@ public class GitPushEmbedded implements GitPusher {
     Process exec(@NotNull ProcessBuilder processBuilder) throws IOException;
   }
 
-  public GitPushEmbedded(@NotNull LocalContext context, @NotNull String preReceive, @NotNull String postReceive, @NotNull String update) {
+  public GitPushEmbedded(@NotNull LocalContext context, @Nullable String preReceive, @Nullable String postReceive, @Nullable String update) {
     this.context = context.getShared();
     this.preReceive = preReceive;
     this.postReceive = postReceive;
@@ -94,7 +94,7 @@ public class GitPushEmbedded implements GitPusher {
     });
   }
 
-  private void runUpdateHook(@NotNull Repository repository, @NotNull RefUpdate refUpdate, @NotNull String hook, @NotNull User userInfo) throws IOException, SVNException {
+  private void runUpdateHook(@NotNull Repository repository, @NotNull RefUpdate refUpdate, @Nullable String hook, @NotNull User userInfo) throws IOException, SVNException {
     runHook(repository, hook, userInfo, processBuilder -> {
       processBuilder.command().addAll(Arrays.asList(
           refUpdate.getName(),
@@ -105,8 +105,8 @@ public class GitPushEmbedded implements GitPusher {
     });
   }
 
-  private void runHook(@NotNull Repository repository, @NotNull String hook, @NotNull User userInfo, @NotNull HookRunner runner) throws IOException, SVNException {
-    if (hook.isEmpty()) {
+  private void runHook(@NotNull Repository repository, @Nullable String hook, @NotNull User userInfo, @NotNull HookRunner runner) throws IOException, SVNException {
+    if (hook == null || hook.isEmpty()) {
       return;
     }
     final File script = ConfigHelper.joinPath(ConfigHelper.joinPath(repository.getDirectory(), "hooks"), hook);

--- a/src/main/java/svnserver/repository/git/push/GitPushEmbeddedConfig.java
+++ b/src/main/java/svnserver/repository/git/push/GitPushEmbeddedConfig.java
@@ -8,6 +8,7 @@
 package svnserver.repository.git.push;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import svnserver.config.GitPusherConfig;
 import svnserver.config.serializer.ConfigType;
 import svnserver.context.LocalContext;
@@ -21,37 +22,37 @@ import svnserver.context.LocalContext;
 public class GitPushEmbeddedConfig implements GitPusherConfig {
   @NotNull
   public static final GitPushEmbeddedConfig instance = new GitPushEmbeddedConfig();
-  @NotNull
+  @Nullable
   private String preReceive = "pre-receive";
-  @NotNull
+  @Nullable
   private String postReceive = "post-receive";
-  @NotNull
+  @Nullable
   private String update = "update";
 
-  @NotNull
+  @Nullable
   public String getPreReceive() {
     return preReceive;
   }
 
-  public void setPreReceive(@NotNull String preCommit) {
+  public void setPreReceive(@Nullable String preCommit) {
     this.preReceive = preCommit;
   }
 
-  @NotNull
+  @Nullable
   public String getPostReceive() {
     return postReceive;
   }
 
-  public void setPostReceive(@NotNull String postReceive) {
+  public void setPostReceive(@Nullable String postReceive) {
     this.postReceive = postReceive;
   }
 
-  @NotNull
+  @Nullable
   public String getUpdate() {
     return update;
   }
 
-  public void setUpdate(@NotNull String update) {
+  public void setUpdate(@Nullable String update) {
     this.update = update;
   }
 

--- a/src/main/java/svnserver/server/command/CommitCmd.java
+++ b/src/main/java/svnserver/server/command/CommitCmd.java
@@ -615,7 +615,7 @@ public final class CommitCmd extends BaseCmd<CommitCmd.CommitParams> {
           //noinspection unchecked
           command.process(context, param);
         } catch (Throwable e) {
-          log.warn("Found error in cmd {}: {}", cmd, e.getMessage());
+          log.warn("Found error in cmd " + cmd, e);
           aborted = true;
           throw e;
         }

--- a/src/test/java/svnserver/ext/gitlfs/storage/local/LfsLocalStorageTest.java
+++ b/src/test/java/svnserver/ext/gitlfs/storage/local/LfsLocalStorageTest.java
@@ -12,6 +12,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import svnserver.TestHelper;
+import svnserver.ext.gitlfs.config.LfsLayout;
 import svnserver.ext.gitlfs.storage.LfsReader;
 import svnserver.ext.gitlfs.storage.LfsWriter;
 
@@ -39,7 +40,7 @@ public class LfsLocalStorageTest {
   public void simple(boolean compress) throws IOException {
     final File tempDir = TestHelper.createTempDir("git-as-svn");
     try {
-      LfsLocalStorage storage = new LfsLocalStorage(new File(tempDir, "data"), new File(tempDir, "meta"), compress);
+      LfsLocalStorage storage = new LfsLocalStorage(LfsLayout.TwoLevels, new File(tempDir, "data"), new File(tempDir, "meta"), compress);
       // Check file is not exists
       Assert.assertNull(storage.getReader("sha256:61f27ddd5b4e533246eb76c45ed4bf4504daabce12589f97b3285e9d3cd54308"));
 
@@ -67,7 +68,7 @@ public class LfsLocalStorageTest {
   public void alreadyAdded(boolean compress) throws IOException {
     final File tempDir = TestHelper.createTempDir("git-as-svn");
     try {
-      LfsLocalStorage storage = new LfsLocalStorage(new File(tempDir, "data"), new File(tempDir, "meta"), compress);
+      LfsLocalStorage storage = new LfsLocalStorage(LfsLayout.TwoLevels, new File(tempDir, "data"), new File(tempDir, "meta"), compress);
       // Check file is not exists
       Assert.assertNull(storage.getReader("sha256:61f27ddd5b4e533246eb76c45ed4bf4504daabce12589f97b3285e9d3cd54308"));
 

--- a/src/test/java/svnserver/ext/gitlfs/storage/network/LfsHttpStorageTest.java
+++ b/src/test/java/svnserver/ext/gitlfs/storage/network/LfsHttpStorageTest.java
@@ -25,6 +25,7 @@ import svnserver.auth.UserDB;
 import svnserver.auth.UserWithPassword;
 import svnserver.context.LocalContext;
 import svnserver.context.SharedContext;
+import svnserver.ext.gitlfs.config.LfsLayout;
 import svnserver.ext.gitlfs.server.LfsServer;
 import svnserver.ext.gitlfs.storage.LfsReader;
 import svnserver.ext.gitlfs.storage.LfsStorage;
@@ -119,7 +120,7 @@ public class LfsHttpStorageTest {
   public void simple(boolean compress) throws IOException {
     final File tempDir = TestHelper.createTempDir("git-as-svn");
     try {
-      LfsLocalStorage storage = new LfsLocalStorage(new File(tempDir, "data"), new File(tempDir, "meta"), compress);
+      LfsLocalStorage storage = new LfsLocalStorage(LfsLayout.TwoLevels, new File(tempDir, "data"), new File(tempDir, "meta"), compress);
       // Check file is not exists
       Assert.assertNull(storage.getReader("sha256:61f27ddd5b4e533246eb76c45ed4bf4504daabce12589f97b3285e9d3cd54308"));
 


### PR DESCRIPTION
Example settings GitLab LFS storage:

```yaml
  # Git LFS server
  - !lfs
    # Secret token for git-lfs-authenticate script
    # token: secret
    path: /mnt/storage/lfs-objects
    saveMeta: false
    compress: false
    layout: GitLab
```