### PR TITLE
Use pre-compiled protoc from maven central

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
 addons:
   apt:
     packages:
-    - protobuf-compiler
     - gnome-doc-utils
 install:
 - ./gradlew assemble

--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,9 @@ jar {
 }
 
 protobuf {
+  protoc {
+    artifact = 'com.google.protobuf:protoc:2.6.1'
+  }
   generatedFilesBaseDir = "$projectDir/src/generated"
 }
 


### PR DESCRIPTION
This avoids conflict with local protoc from PATH,  I have protoc 3.0 beta at PATH, but it doesn't work for git-as-svn.