### PR TITLE
Fix cached revisions fast check

### DIFF
--- a/src/main/java/svnserver/repository/git/GitRepository.java
+++ b/src/main/java/svnserver/repository/git/GitRepository.java
@@ -171,7 +171,7 @@ public class GitRepository implements VcsRepository {
       final int lastRevision = revisions.size() - 1;
       final ObjectId lastCommitId;
       if (lastRevision >= 0) {
-        lastCommitId = revisions.get(lastRevision).getGitNewCommit();
+        lastCommitId = revisions.get(lastRevision).getCacheCommit();
         final Ref head = repository.getRef(svnBranch);
         if (head.getObjectId().equals(lastCommitId)) {
           return false;


### PR DESCRIPTION
`getGitNewCommit` returns the original git commit, but `head.getObjectId()` returns the head commit of the svn cache branch, they never equals.