### PR TITLE
Revert "Merge 'assembleDist' Gradle task into 'assemble'"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ addons:
     - debhelper
     - gnome-doc-utils
 
+before_deploy:
+- ./gradlew assembleDist
+
 deploy:
   - provider: releases
     api-key:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node {
   sh 'git clean -ffdx'
 
   stage 'Build'
-  sh './gradlew assemble'
+  sh './gradlew assembleDist'
   archive 'build/distributions/*'
 
   stage 'Test'

--- a/build.gradle
+++ b/build.gradle
@@ -219,7 +219,7 @@ task assembleDeb(type: Copy, dependsOn: distDeb) {
   into "$buildDir/distributions"
 }
 
-tasks.assemble.dependsOn(assembleDeb)
+assembleDist.dependsOn(assembleDeb)
 
 distZip {
   archiveName "${project.name}_${project.version}.zip"

--- a/docbook/src/main/reference/ch_install.xml
+++ b/docbook/src/main/reference/ch_install.xml
@@ -259,7 +259,7 @@ ssh git@remote -C "git-lfs-authenticate example download"</programlisting>
 
     <para>Полностью собрать дистрибутив можно командой:</para>
 
-    <programlisting language="bash" xml:lang="C">./gradlew assemble</programlisting>
+    <programlisting language="bash" xml:lang="C">./gradlew assembleDist</programlisting>
 
     <para>Комплект установочных файлов будет располагаться в директории:
     <filename>build/distributions</filename></para>


### PR DESCRIPTION
Reverts bozaro/git-as-svn#147

Because it broke documentation publishing from Travis