### PR TITLE
Fix git-as-svn unable to find prefix-mapped repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 1.1.8
+
+ * Fix git-as-svn unable to find prefix-mapped repositories (broken in 1.1.2)
+
 ## 1.1.7
 
  * Use OAuth2 to obtain user token. Fixes compatibility with GitLab >= 10.2 #154

--- a/src/main/java/svnserver/repository/mapping/RepositoryListMapping.java
+++ b/src/main/java/svnserver/repository/mapping/RepositoryListMapping.java
@@ -30,7 +30,11 @@ public final class RepositoryListMapping implements VcsRepositoryMapping {
   private final NavigableMap<String, VcsRepository> mapping;
 
   public RepositoryListMapping(@NotNull Map<String, VcsRepository> mapping) {
-    this.mapping = new TreeMap<>(mapping);
+    this.mapping = new TreeMap<>();
+
+    mapping.forEach((path, repository) -> {
+      RepositoryListMapping.this.mapping.put(StringHelper.normalizeDir(path), repository);
+    });
   }
 
   @Nullable

--- a/src/main/java/svnserver/server/command/DeltaCmd.java
+++ b/src/main/java/svnserver/server/command/DeltaCmd.java
@@ -178,9 +178,13 @@ public final class DeltaCmd extends BaseCmd<DeltaParams> {
 
     private class HeaderEntry implements AutoCloseable {
 
+      @NotNull
       private final SessionContext context;
+      @Nullable
       private final VcsFile file;
+      @NotNull
       private final HeaderWriter beginWriter;
+      @NotNull
       private final HeaderWriter endWriter;
       private boolean writed = false;
 

--- a/src/test/java/svnserver/SvnTestServer.java
+++ b/src/test/java/svnserver/SvnTestServer.java
@@ -152,7 +152,7 @@ public final class SvnTestServer implements SvnTester {
   @NotNull
   public static SvnTestServer createEmpty() throws Exception {
     final String branch = "master";
-    return new SvnTestServer(TestHelper.emptyRepository(), branch, "", false, null, true);
+    return new SvnTestServer(TestHelper.emptyRepository(), branch, "foo", false, null, true);
   }
 
   @NotNull
@@ -163,7 +163,7 @@ public final class SvnTestServer implements SvnTester {
 
   @NotNull
   public static SvnTestServer createMasterRepository() throws Exception {
-    return new SvnTestServer(new FileRepository(TestHelper.findGitPath()), null, "/master", true, null, true);
+    return new SvnTestServer(new FileRepository(TestHelper.findGitPath()), null, "master", true, null, true);
   }
 
   @Override


### PR DESCRIPTION
Broken by commit 06a11acc5a293a9d86375f0c399e11d2e3d7d454.