### PR TITLE
Fix bug with adding projects in gitea

### DIFF
--- a/src/main/java/svnserver/ext/gitea/mapping/GiteaMapper.java
+++ b/src/main/java/svnserver/ext/gitea/mapping/GiteaMapper.java
@@ -55,8 +55,8 @@ public class GiteaMapper extends Thread implements DirectoryWatcher.DirectoryMap
               GiteaProject project = mapping.addRepository(repository);
               if (project != null) {
                 project.initRevisions();
-                it.remove();
               }
+              it.remove();
             } catch (ApiException e) {
               // Not ready yet - try again later...
             } catch (IOException | SVNException e) {


### PR DESCRIPTION
Sorry about this, I just noticed that there is a bug in my implementation of the GiteaMapper. If the project is already in the git-as-svn mapdb then the API will be repolled every second checking if the project has changed ID.

Please accept my apologies for this silly error. This pull will fix this error.