### PR TITLE
Add in search-by-uid capability for Gitea (>1.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,6 @@ Also you need to set ```baseUrl``` parameter in ```!web``` section of git-as-svn
 ## Gitea Integration
 There is also integration with Gitea >=v1.6. (Requires Sudo API) Remember to run git-as-svn as the git user.
 
-* svn+ssh support is questionable...
-
 # How to use
 
 ## Install on Ubuntu/Debian

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ dependencies {
   compile "org.eclipse.jetty:jetty-servlet:9.4.12.v20180830"
   compile "org.gitlab:java-gitlab-api:4.1.0"
   compile "org.bitbucket.b_c:jose4j:0.6.4"
-  compile "com.github.zeripath:java-gitea-api:1.6.0-SNAPSHOT"
+  compile "com.github.zeripath:java-gitea-api:1.7.0-SNAPSHOT"
 
   compile "ru.bozaro.gitlfs:gitlfs-pointer:0.11.1"
   compile "ru.bozaro.gitlfs:gitlfs-client:0.11.1"

--- a/src/main/java/svnserver/ext/gitea/auth/GiteaUserDB.java
+++ b/src/main/java/svnserver/ext/gitea/auth/GiteaUserDB.java
@@ -105,10 +105,11 @@ public final class GiteaUserDB implements UserDB {
     final String userId = external;
     if (userId != null) {
       try {
+        Long uid = Long.parseLong(userId);
         final UserApi userApi = new UserApi(context.connect());
-        UserSearchList users = userApi.userSearch(null, null);
+        UserSearchList users = userApi.userSearch(null, uid, null);
         for (io.gitea.model.User u : users.getData()) {
-          if (userId.equals("" + u.getId())) {
+          if (uid.equals(u.getId())) {
             return createUser(u);
           }
         }

--- a/src/main/java/svnserver/ext/gitea/mapping/GiteaAccess.java
+++ b/src/main/java/svnserver/ext/gitea/mapping/GiteaAccess.java
@@ -68,7 +68,7 @@ final class GiteaAccess implements VcsAccess {
               try {
                 final ApiClient apiClient = context.connect();
                 final RepositoryApi repositoryApi = new RepositoryApi(apiClient);
-                final Repository repository = repositoryApi.repoGetByID((int) projectId);
+                final Repository repository = repositoryApi.repoGetByID(projectId);
                 if (!repository.isPrivate()) {
                   // Munge the permissions
                   repository.getPermissions().setAdmin(false);
@@ -88,7 +88,7 @@ final class GiteaAccess implements VcsAccess {
               final ApiClient apiClient = context.connect(userName);
               final RepositoryApi repositoryApi = new RepositoryApi(apiClient);
 
-              final Repository repository = repositoryApi.repoGetByID((int) projectId);
+              final Repository repository = repositoryApi.repoGetByID(projectId);
               return repository;
             } catch (ApiException e) {
               if (e.getCode() == 404) {

--- a/src/main/java/svnserver/ext/gitea/mapping/GiteaMappingConfig.java
+++ b/src/main/java/svnserver/ext/gitea/mapping/GiteaMappingConfig.java
@@ -91,7 +91,7 @@ public final class GiteaMappingConfig implements RepositoryMappingConfig {
     final GiteaMapping mapping = new GiteaMapping(context, this);
     
     try {
-      final UserSearchList usersList = userApi.userSearch(null, null);
+      final UserSearchList usersList = userApi.userSearch(null, null, null);
     
       for (User u : usersList.getData()) {
         List<Repository> repositories = userApi.userListRepos(u.getLogin());


### PR DESCRIPTION
Following the release of Gitea v1.6.0 my pull request 
https://github.com/go-gitea/gitea/pull/4876 has been merged
allowing search by uid. This pull requests adds this.

This should still work on Gitea v1.6.0 - as the uid parameter will
simply be ignored on these versions. The other changes in the
java-gitea-api regarding the use of long are just better
representations than those originally listed in the swagger api.