### PR TITLE
Revert "Add in search-by-uid capability for Gitea (>1.7.0)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Also you need to set ```baseUrl``` parameter in ```!web``` section of git-as-svn
 ## Gitea Integration
 There is also integration with Gitea >=v1.6. (Requires Sudo API) Remember to run git-as-svn as the git user.
 
+* svn+ssh support is questionable...
+
 # How to use
 
 ## Install on Ubuntu/Debian

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ dependencies {
   compile "org.eclipse.jetty:jetty-servlet:9.4.12.v20180830"
   compile "org.gitlab:java-gitlab-api:4.1.0"
   compile "org.bitbucket.b_c:jose4j:0.6.4"
-  compile "com.github.zeripath:java-gitea-api:1.7.0-SNAPSHOT"
+  compile "com.github.zeripath:java-gitea-api:1.6.0-SNAPSHOT"
 
   compile "ru.bozaro.gitlfs:gitlfs-pointer:0.11.1"
   compile "ru.bozaro.gitlfs:gitlfs-client:0.11.1"

--- a/src/main/java/svnserver/ext/gitea/auth/GiteaUserDB.java
+++ b/src/main/java/svnserver/ext/gitea/auth/GiteaUserDB.java
@@ -105,11 +105,10 @@ public final class GiteaUserDB implements UserDB {
     final String userId = external;
     if (userId != null) {
       try {
-        Long uid = Long.parseLong(userId);
         final UserApi userApi = new UserApi(context.connect());
-        UserSearchList users = userApi.userSearch(null, uid, null);
+        UserSearchList users = userApi.userSearch(null, null);
         for (io.gitea.model.User u : users.getData()) {
-          if (uid.equals(u.getId())) {
+          if (userId.equals("" + u.getId())) {
             return createUser(u);
           }
         }

--- a/src/main/java/svnserver/ext/gitea/mapping/GiteaAccess.java
+++ b/src/main/java/svnserver/ext/gitea/mapping/GiteaAccess.java
@@ -68,7 +68,7 @@ final class GiteaAccess implements VcsAccess {
               try {
                 final ApiClient apiClient = context.connect();
                 final RepositoryApi repositoryApi = new RepositoryApi(apiClient);
-                final Repository repository = repositoryApi.repoGetByID(projectId);
+                final Repository repository = repositoryApi.repoGetByID((int) projectId);
                 if (!repository.isPrivate()) {
                   // Munge the permissions
                   repository.getPermissions().setAdmin(false);
@@ -88,7 +88,7 @@ final class GiteaAccess implements VcsAccess {
               final ApiClient apiClient = context.connect(userName);
               final RepositoryApi repositoryApi = new RepositoryApi(apiClient);
 
-              final Repository repository = repositoryApi.repoGetByID(projectId);
+              final Repository repository = repositoryApi.repoGetByID((int) projectId);
               return repository;
             } catch (ApiException e) {
               if (e.getCode() == 404) {

--- a/src/main/java/svnserver/ext/gitea/mapping/GiteaMappingConfig.java
+++ b/src/main/java/svnserver/ext/gitea/mapping/GiteaMappingConfig.java
@@ -91,7 +91,7 @@ public final class GiteaMappingConfig implements RepositoryMappingConfig {
     final GiteaMapping mapping = new GiteaMapping(context, this);
     
     try {
-      final UserSearchList usersList = userApi.userSearch(null, null, null);
+      final UserSearchList usersList = userApi.userSearch(null, null);
     
       for (User u : usersList.getData()) {
         List<Repository> repositories = userApi.userListRepos(u.getLogin());


### PR DESCRIPTION
Reverts bozaro/git-as-svn#206

Doesn't pass tests: https://travis-ci.org/bozaro/git-as-svn/jobs/445088819

```svnserver.ext.gitea.GiteaIntegrationTest.before FAILED
    io.gitea.ApiException: Content type "text/html; charset=UTF-8" is not supported for type: class io.gitea.model.AccessToken
        at io.gitea.ApiClient.deserialize(ApiClient.java:725)
        at io.gitea.ApiClient.handleResponse(ApiClient.java:920)
        at io.gitea.ApiClient.execute(ApiClient.java:847)
        at io.gitea.api.UserApi.userCreateTokenWithHttpInfo(UserApi.java:522)
        at io.gitea.api.UserApi.userCreateToken(UserApi.java:507)
        at svnserver.ext.gitea.GiteaIntegrationTest.before(GiteaIntegrationTest.java:119)```