### PR TITLE
Introduce 'strict protocol' mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
  * File locking code cleanup. All existing svn locks will expire after upgrade.
  * Implement `get-file-revs` command. This is expected to speed up `svn blame` severely. #231
  * [Prospective blame](https://subversion.apache.org/docs/release-notes/1.9#prospective-blame) support added
+ * Introduce 'strict protocol' mode. git-as-svn no longer silently skips unsupported command options and instead raises exception
+   if client sends unexpected data. This is required to make sure we're 100% network-compatible with native Subversion and do not
+   silently ignore important data. In case of unexpected bugs, this mode can be disabled with `strictProtocol: false` in git-as-svn.conf
 
 ## 1.9.0
 

--- a/src/main/java/svnserver/config/Config.java
+++ b/src/main/java/svnserver/config/Config.java
@@ -27,6 +27,7 @@ public final class Config {
   private String host = "0.0.0.0";
   @NotNull
   private String realm = "";
+  private boolean strictProtocol = true;
 
   @NotNull
   private RepositoryMappingConfig repositoryMapping = new RepositoryListMappingConfig();
@@ -120,5 +121,9 @@ public final class Config {
 
   public void setCompressionEnabled(boolean compressionEnabled) {
     this.compressionEnabled = compressionEnabled;
+  }
+
+  public boolean useStrictProtocol() {
+    return strictProtocol;
   }
 }

--- a/src/main/java/svnserver/parser/MessageParser.java
+++ b/src/main/java/svnserver/parser/MessageParser.java
@@ -59,7 +59,7 @@ public final class MessageParser {
 
   @SuppressWarnings("unchecked")
   @NotNull
-  private static <T> T parseObject(Class<T> type, @Nullable SvnServerParser tokenParser) throws IOException {
+  private static <T> T parseObject(@NotNull Class<T> type, @Nullable SvnServerParser tokenParser) throws IOException {
     if (tokenParser != null && tokenParser.readItem(ListBeginToken.class) == null)
       tokenParser = null;
 
@@ -92,8 +92,12 @@ public final class MessageParser {
       params[i] = parse(ctorParams[i].getType(), getDepth(tokenParser) == depth ? tokenParser : null);
     }
     while (tokenParser != null && getDepth(tokenParser) >= depth) {
-      tokenParser.readToken();
+      if (tokenParser.useStrictProtocol())
+        tokenParser.readToken(ListEndToken.class);
+      else
+        tokenParser.readToken();
     }
+
     try {
       if (!ctor.isAccessible())
         ctor.setAccessible(true);

--- a/src/main/java/svnserver/parser/SvnServerParser.java
+++ b/src/main/java/svnserver/parser/SvnServerParser.java
@@ -32,18 +32,24 @@ public final class SvnServerParser {
   private final InputStream stream;
   private int depth = 0;
 
+  private final boolean strictProtocol;
   @NotNull
   private final byte[] buffer;
   private int offset = 0;
   private int limit = 0;
 
-  public SvnServerParser(@NotNull InputStream stream, int bufferSize) {
+  public SvnServerParser(@NotNull InputStream stream, boolean strictProtocol, int bufferSize) {
     this.stream = stream;
+    this.strictProtocol = strictProtocol;
     this.buffer = new byte[Math.max(1, bufferSize)];
   }
 
+  public SvnServerParser(@NotNull InputStream stream, boolean strictProtocol) {
+    this(stream, strictProtocol, DEFAULT_BUFFER_SIZE);
+  }
+
   public SvnServerParser(@NotNull InputStream stream) {
-    this(stream, DEFAULT_BUFFER_SIZE);
+    this(stream, true, DEFAULT_BUFFER_SIZE);
   }
 
   @NotNull
@@ -103,7 +109,7 @@ public final class SvnServerParser {
    */
   @SuppressWarnings("OverlyComplexMethod")
   @NotNull
-  public SvnServerToken readToken() throws IOException {
+  SvnServerToken readToken() throws IOException {
     byte read = skipSpaces();
     if (read == '(') {
       depth++;
@@ -260,5 +266,8 @@ public final class SvnServerParser {
       }
     }
   }
-}
 
+  boolean useStrictProtocol() {
+    return strictProtocol;
+  }
+}

--- a/src/main/java/svnserver/server/command/DeltaCmd.java
+++ b/src/main/java/svnserver/server/command/DeltaCmd.java
@@ -240,7 +240,6 @@ public final class DeltaCmd extends BaseCmd<DeltaParams> {
     @SuppressWarnings("unchecked")
     private void reportCommand(@NotNull SessionContext context) throws IOException, SVNException {
       final SvnServerParser parser = context.getParser();
-      final SvnServerWriter writer = context.getWriter();
       parser.readToken(ListBeginToken.class);
       final String cmd = parser.readText();
       log.debug("Report command: {}", cmd);
@@ -250,9 +249,7 @@ public final class DeltaCmd extends BaseCmd<DeltaParams> {
         parser.readToken(ListEndToken.class);
         command.process(context, param);
       } else {
-        log.error("Unsupported command: {}", cmd);
-        BaseCmd.sendError(writer, SVNErrorMessage.create(SVNErrorCode.RA_SVN_UNKNOWN_CMD, "Unsupported command: " + cmd));
-        parser.skipItems();
+        context.skipUnsupportedCommand(cmd);
       }
     }
 

--- a/src/main/java/svnserver/server/msg/ClientInfo.java
+++ b/src/main/java/svnserver/server/msg/ClientInfo.java
@@ -13,8 +13,10 @@ import org.tmatesoft.svn.core.SVNURL;
 
 /**
  * Информация о подключенном клиенте.
- * <p>
- * response: ( version:number ( cap:word ... ) url:string ? ra-client:string ( ? client:string ) )
+ * <pre>
+ *     response: ( version:number ( cap:word ... ) url:string
+ *               ? ra-client:string ( ? client:string ) )
+ * </pre>
  *
  * @author a.navrotskiy
  */
@@ -25,13 +27,16 @@ public class ClientInfo {
   @NotNull
   private final SVNURL url;
   @NotNull
-  private final String userAgent;
+  private final String raClient;
+  @NotNull
+  private final String[] client;
 
-  public ClientInfo(int protocolVersion, @NotNull String[] capabilities, @NotNull String url, @NotNull String userAgent) throws SVNException {
+  public ClientInfo(int protocolVersion, @NotNull String[] capabilities, @NotNull String url, @NotNull String raClient, @NotNull String[] client) throws SVNException {
     this.protocolVersion = protocolVersion;
     this.capabilities = capabilities;
     this.url = SVNURL.parseURIEncoded(url);
-    this.userAgent = userAgent;
+    this.raClient = raClient;
+    this.client = client;
   }
 
   public int getProtocolVersion() {
@@ -49,7 +54,7 @@ public class ClientInfo {
   }
 
   @NotNull
-  public String getUserAgent() {
-    return userAgent;
+  public String getRaClient() {
+    return raClient;
   }
 }

--- a/src/main/java/svnserver/server/msg/PropertyEntry.java
+++ b/src/main/java/svnserver/server/msg/PropertyEntry.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
+package svnserver.server.msg;
+
+import org.jetbrains.annotations.NotNull;
+
+public final class PropertyEntry {
+  @NotNull
+  private final String name;
+  @NotNull
+  private final String value;
+
+  public PropertyEntry(@NotNull String name, @NotNull String value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  @NotNull
+  public String getName() {
+    return name;
+  }
+
+  @NotNull
+  public String getValue() {
+    return value;
+  }
+}

--- a/src/test/java/svnserver/parser/SvnServerParserTest.java
+++ b/src/test/java/svnserver/parser/SvnServerParserTest.java
@@ -27,18 +27,18 @@ public class SvnServerParserTest {
   public void testSimpleParse() throws IOException {
     try (InputStream stream = new ByteArrayInputStream("( word 22 10:string 1:x 1:  8:Тест ( sublist ) ) ".getBytes(StandardCharsets.UTF_8))) {
       final SvnServerParser parser = new SvnServerParser(stream);
-      Assert.assertEquals(parser.readToken(), ListBeginToken.instance);
-      Assert.assertEquals(parser.readToken(), new WordToken("word"));
-      Assert.assertEquals(parser.readToken(), new NumberToken(22));
-      Assert.assertEquals(parser.readToken(), new StringToken("string 1:x"));
-      Assert.assertEquals(parser.readToken(), new StringToken(" "));
-      Assert.assertEquals(parser.readToken(), new StringToken("Тест"));
-      Assert.assertEquals(parser.readToken(), ListBeginToken.instance);
-      Assert.assertEquals(parser.readToken(), new WordToken("sublist"));
-      Assert.assertEquals(parser.readToken(), ListEndToken.instance);
-      Assert.assertEquals(parser.readToken(), ListEndToken.instance);
+      Assert.assertEquals(parser.readToken(ListBeginToken.class), ListBeginToken.instance);
+      Assert.assertEquals(parser.readToken(WordToken.class), new WordToken("word"));
+      Assert.assertEquals(parser.readToken(NumberToken.class), new NumberToken(22));
+      Assert.assertEquals(parser.readToken(StringToken.class), new StringToken("string 1:x"));
+      Assert.assertEquals(parser.readToken(StringToken.class), new StringToken(" "));
+      Assert.assertEquals(parser.readToken(StringToken.class), new StringToken("Тест"));
+      Assert.assertEquals(parser.readToken(ListBeginToken.class), ListBeginToken.instance);
+      Assert.assertEquals(parser.readToken(WordToken.class), new WordToken("sublist"));
+      Assert.assertEquals(parser.readToken(ListEndToken.class), ListEndToken.instance);
+      Assert.assertEquals(parser.readToken(ListEndToken.class), ListEndToken.instance);
       try {
-        parser.readToken();
+        parser.readToken(ListEndToken.class);
         Assert.fail();
       } catch (EOFException ignored) {
       }
@@ -49,19 +49,19 @@ public class SvnServerParserTest {
   @Test
   public void testSimpleParseSmallBuffer() throws IOException {
     try (InputStream stream = new ByteArrayInputStream("( word 22 10:string 1:x 1:  8:Тест ( sublist ) ) ".getBytes(StandardCharsets.UTF_8))) {
-      final SvnServerParser parser = new SvnServerParser(stream, 10);
-      Assert.assertEquals(parser.readToken(), ListBeginToken.instance);
-      Assert.assertEquals(parser.readToken(), new WordToken("word"));
-      Assert.assertEquals(parser.readToken(), new NumberToken(22));
-      Assert.assertEquals(parser.readToken(), new StringToken("string 1:x"));
-      Assert.assertEquals(parser.readToken(), new StringToken(" "));
-      Assert.assertEquals(parser.readToken(), new StringToken("Тест"));
-      Assert.assertEquals(parser.readToken(), ListBeginToken.instance);
-      Assert.assertEquals(parser.readToken(), new WordToken("sublist"));
-      Assert.assertEquals(parser.readToken(), ListEndToken.instance);
-      Assert.assertEquals(parser.readToken(), ListEndToken.instance);
+      final SvnServerParser parser = new SvnServerParser(stream, true, 10);
+      Assert.assertEquals(parser.readToken(ListBeginToken.class), ListBeginToken.instance);
+      Assert.assertEquals(parser.readToken(WordToken.class), new WordToken("word"));
+      Assert.assertEquals(parser.readToken(NumberToken.class), new NumberToken(22));
+      Assert.assertEquals(parser.readToken(StringToken.class), new StringToken("string 1:x"));
+      Assert.assertEquals(parser.readToken(StringToken.class), new StringToken(" "));
+      Assert.assertEquals(parser.readToken(StringToken.class), new StringToken("Тест"));
+      Assert.assertEquals(parser.readToken(ListBeginToken.class), ListBeginToken.instance);
+      Assert.assertEquals(parser.readToken(WordToken.class), new WordToken("sublist"));
+      Assert.assertEquals(parser.readToken(ListEndToken.class), ListEndToken.instance);
+      Assert.assertEquals(parser.readToken(ListEndToken.class), ListEndToken.instance);
       try {
-        parser.readToken();
+        parser.readToken(ListEndToken.class);
         Assert.fail();
       } catch (EOFException ignored) {
       }
@@ -88,7 +88,7 @@ public class SvnServerParserTest {
       ClientInfo req = MessageParser.parse(ClientInfo.class, parser);
       Assert.assertEquals(req.getProtocolVersion(), 2);
       Assert.assertEquals(req.getUrl().toString(), "svn://localhost");
-      Assert.assertEquals(req.getUserAgent(), "SVN/1.8.8 (x86_64-pc-linux-gnu)");
+      Assert.assertEquals(req.getRaClient(), "SVN/1.8.8 (x86_64-pc-linux-gnu)");
       ArrayAsserts.assertArrayEquals(new String[]{
           "edit-pipeline",
           "svndiff1",
@@ -108,7 +108,7 @@ public class SvnServerParserTest {
       ClientInfo req = MessageParser.parse(ClientInfo.class, parser);
       Assert.assertEquals(req.getProtocolVersion(), 2);
       Assert.assertEquals(req.getUrl().toString(), "svn://localhost");
-      Assert.assertEquals(req.getUserAgent(), "");
+      Assert.assertEquals(req.getRaClient(), "");
       ArrayAsserts.assertArrayEquals(new String[]{
           "edit-pipeline",
           "svndiff1",
@@ -137,9 +137,9 @@ public class SvnServerParserTest {
     }
     try (ByteArrayInputStream inputStream = new ByteArrayInputStream(streamData)) {
       final SvnServerParser parser = new SvnServerParser(inputStream);
-      Assert.assertEquals(parser.readToken(), new StringToken(data));
-      Assert.assertEquals(parser.readToken(), new StringToken(data));
-      Assert.assertEquals(parser.readToken(), new WordToken("end"));
+      Assert.assertEquals(parser.readToken(StringToken.class), new StringToken(data));
+      Assert.assertEquals(parser.readToken(StringToken.class), new StringToken(data));
+      Assert.assertEquals(parser.readToken(WordToken.class), new WordToken("end"));
     }
   }
 }

--- a/src/test/java/svnserver/server/SvnUpdateTest.java
+++ b/src/test/java/svnserver/server/SvnUpdateTest.java
@@ -27,7 +27,7 @@ import java.io.File;
  *
  * @author Artem V. Navrotskiy <bozaro@users.noreply.github.com>
  */
-public class SvnUpdateTest {
+public final class SvnUpdateTest {
   /**
    * Bug: svn up doesnt remove file #18
    * <pre>
@@ -45,8 +45,6 @@ public class SvnUpdateTest {
    * -rw-rw-r-- 1 bozaro bozaro 1 авг.  15 00:50 test.txt
    * bozaro@landfill:/tmp/test/git-as-svn$
    * </pre>
-   *
-   * @throws Exception
    */
   @Test
   public void addAndUpdate() throws Exception {


### PR DESCRIPTION
git-as-svn no longer silently skips unsupported command options and instead raises
exception if client sends unexpected data. This is required to make sure we're 100%
network-compatible with native Subversion and do not silently ignore important data.
In case of unexpected bugs, this mode can be disabled with `strictProtocol: false`
in git-as-svn.conf