### PR TITLE
Revert 'strict protocol' thing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
  * File locking code cleanup. All existing svn locks will expire after upgrade.
  * Implement `get-file-revs` command. This is expected to speed up `svn blame` severely. #231
  * [Prospective blame](https://subversion.apache.org/docs/release-notes/1.9#prospective-blame) support added
- * Introduce 'strict protocol' mode. git-as-svn no longer silently skips unsupported command options and instead raises exception
-   if client sends unexpected data. This is required to make sure we're 100% network-compatible with native Subversion and do not
-   silently ignore important data. In case of unexpected bugs, this mode can be disabled with `strictProtocol: false` in git-as-svn.conf
 
 ## 1.9.0
 

--- a/src/main/java/svnserver/config/Config.java
+++ b/src/main/java/svnserver/config/Config.java
@@ -27,7 +27,6 @@ public final class Config {
   private String host = "0.0.0.0";
   @NotNull
   private String realm = "";
-  private boolean strictProtocol = true;
 
   @NotNull
   private RepositoryMappingConfig repositoryMapping = new RepositoryListMappingConfig();
@@ -121,9 +120,5 @@ public final class Config {
 
   public void setCompressionEnabled(boolean compressionEnabled) {
     this.compressionEnabled = compressionEnabled;
-  }
-
-  public boolean useStrictProtocol() {
-    return strictProtocol;
   }
 }

--- a/src/main/java/svnserver/parser/MessageParser.java
+++ b/src/main/java/svnserver/parser/MessageParser.java
@@ -92,9 +92,6 @@ public final class MessageParser {
       params[i] = parse(ctorParams[i].getType(), getDepth(tokenParser) == depth ? tokenParser : null);
     }
     while (tokenParser != null && getDepth(tokenParser) >= depth) {
-      if (tokenParser.useStrictProtocol())
-        tokenParser.readToken(ListEndToken.class);
-      else
         tokenParser.readToken();
     }
 

--- a/src/main/java/svnserver/parser/SvnServerParser.java
+++ b/src/main/java/svnserver/parser/SvnServerParser.java
@@ -32,24 +32,18 @@ public final class SvnServerParser {
   private final InputStream stream;
   private int depth = 0;
 
-  private final boolean strictProtocol;
   @NotNull
   private final byte[] buffer;
   private int offset = 0;
   private int limit = 0;
 
-  public SvnServerParser(@NotNull InputStream stream, boolean strictProtocol, int bufferSize) {
+  public SvnServerParser(@NotNull InputStream stream, int bufferSize) {
     this.stream = stream;
-    this.strictProtocol = strictProtocol;
     this.buffer = new byte[Math.max(1, bufferSize)];
   }
 
-  public SvnServerParser(@NotNull InputStream stream, boolean strictProtocol) {
-    this(stream, strictProtocol, DEFAULT_BUFFER_SIZE);
-  }
-
   public SvnServerParser(@NotNull InputStream stream) {
-    this(stream, true, DEFAULT_BUFFER_SIZE);
+    this(stream, DEFAULT_BUFFER_SIZE);
   }
 
   @NotNull
@@ -265,9 +259,5 @@ public final class SvnServerParser {
         depth--;
       }
     }
-  }
-
-  boolean useStrictProtocol() {
-    return strictProtocol;
   }
 }

--- a/src/main/java/svnserver/server/command/CommitCmd.java
+++ b/src/main/java/svnserver/server/command/CommitCmd.java
@@ -619,21 +619,28 @@ public final class CommitCmd extends BaseCmd<CommitCmd.CommitParams> {
         context.push(this::editorCommand);
         command = commands.get(cmd);
       }
-      if (command != null && !aborted) {
-        try {
-          Object param = MessageParser.parse(command.getArguments(), parser);
-          parser.readToken(ListEndToken.class);
-          command.process(context, param);
-        } catch (SVNException e) {
-          aborted = true;
-          throw e;
-        } catch (Throwable e) {
-          log.warn("Exception during in cmd " + cmd, e);
-          aborted = true;
-          throw e;
-        }
-      } else {
+
+      if (command == null) {
         context.skipUnsupportedCommand(cmd);
+        return;
+      }
+
+      if (aborted) {
+        parser.skipItems();
+        return;
+      }
+
+      try {
+        Object param = MessageParser.parse(command.getArguments(), parser);
+        parser.readToken(ListEndToken.class);
+        command.process(context, param);
+      } catch (SVNException e) {
+        aborted = true;
+        throw e;
+      } catch (Throwable e) {
+        log.warn("Exception during in cmd " + cmd, e);
+        aborted = true;
+        throw e;
       }
     }
   }

--- a/src/main/java/svnserver/server/command/DeltaCmd.java
+++ b/src/main/java/svnserver/server/command/DeltaCmd.java
@@ -244,13 +244,14 @@ public final class DeltaCmd extends BaseCmd<DeltaParams> {
       final String cmd = parser.readText();
       log.debug("Report command: {}", cmd);
       final BaseCmd command = commands.get(cmd);
-      if (command != null) {
-        Object param = MessageParser.parse(command.getArguments(), parser);
-        parser.readToken(ListEndToken.class);
-        command.process(context, param);
-      } else {
+      if (command == null) {
         context.skipUnsupportedCommand(cmd);
+        return;
       }
+
+      Object param = MessageParser.parse(command.getArguments(), parser);
+      parser.readToken(ListEndToken.class);
+      command.process(context, param);
     }
 
     @NotNull

--- a/src/test/java/svnserver/parser/SvnServerParserTest.java
+++ b/src/test/java/svnserver/parser/SvnServerParserTest.java
@@ -49,7 +49,7 @@ public class SvnServerParserTest {
   @Test
   public void testSimpleParseSmallBuffer() throws IOException {
     try (InputStream stream = new ByteArrayInputStream("( word 22 10:string 1:x 1:  8:Тест ( sublist ) ) ".getBytes(StandardCharsets.UTF_8))) {
-      final SvnServerParser parser = new SvnServerParser(stream, true, 10);
+      final SvnServerParser parser = new SvnServerParser(stream, 10);
       Assert.assertEquals(parser.readToken(ListBeginToken.class), ListBeginToken.instance);
       Assert.assertEquals(parser.readToken(WordToken.class), new WordToken("word"));
       Assert.assertEquals(parser.readToken(NumberToken.class), new NumberToken(22));


### PR DESCRIPTION
According to svn protocol:

> For extensibility, implementations must treat a list as matching a
> prototype's tuple even if the list contains extra elements.  The extra
> elements must be ignored.

This commit partially reverts d5380b992384a168b2a00a3eb2ce72d005d75e75.