### PR TITLE
Fix PLAIN auth not working with passwords > 51 char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+ * Fix PLAIN auth not working with passwords longer than 51 character. #242
+
 ## 1.10.0
 
  * File locking code cleanup. All existing svn locks will expire after upgrade.

--- a/src/main/java/svnserver/auth/PlainAuthenticator.java
+++ b/src/main/java/svnserver/auth/PlainAuthenticator.java
@@ -37,7 +37,8 @@ public final class PlainAuthenticator implements Authenticator {
   @Nullable
   @Override
   public User authenticate(@NotNull SvnServerParser parser, @NotNull SvnServerWriter writer, @NotNull String token) throws SVNException {
-    final String decodedToken = new String(Base64.getDecoder().decode(token.trim()), StandardCharsets.US_ASCII);
+    final byte[] decoded = Base64.getMimeDecoder().decode(token);
+    final String decodedToken = new String(decoded, StandardCharsets.US_ASCII);
     final String[] credentials = decodedToken.split("\u0000");
     if (credentials.length < 3)
       return null;

--- a/src/test/java/svnserver/ldap/AuthLdapTest.java
+++ b/src/test/java/svnserver/ldap/AuthLdapTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public final class AuthLdapTest {
 
   /**
-   * Test for #156.
+   * Test for #156, #242.
    */
   @Test
   void nativeClient() throws Exception {
@@ -43,7 +43,7 @@ public final class AuthLdapTest {
         EmbeddedDirectoryServer ldap = EmbeddedDirectoryServer.create();
         SvnTestServer server = SvnTestServer.createEmpty(ldap.createUserConfig(), false)
     ) {
-      final String[] command = {svn, "--non-interactive", "ls", "--username=ldapadmin", "--password=ldapadmin", server.getUrl().toString()};
+      final String[] command = {svn, "--non-interactive", "ls", "--username=ldapadmin", "--password=" + EmbeddedDirectoryServer.ADMIN_PASSWORD, server.getUrl().toString()};
       final int exitCode = new ProcessBuilder(command)
           .redirectError(ProcessBuilder.Redirect.INHERIT)
           .redirectOutput(ProcessBuilder.Redirect.INHERIT)
@@ -55,7 +55,7 @@ public final class AuthLdapTest {
 
   @Test
   public void validUser() throws Throwable {
-    checkUser("ldapadmin", "ldapadmin");
+    checkUser("ldapadmin", EmbeddedDirectoryServer.ADMIN_PASSWORD);
   }
 
   private void checkUser(@NotNull String login, @NotNull String password) throws Exception {
@@ -79,7 +79,7 @@ public final class AuthLdapTest {
 
       final List<Callable<Void>> tasks = new ArrayList<>();
       for (int i = 0; i < 1000; ++i) {
-        tasks.add(new SuccessAuth(userDB, done, "ldapadmin", "ldapadmin"));
+        tasks.add(new SuccessAuth(userDB, done, "ldapadmin", EmbeddedDirectoryServer.ADMIN_PASSWORD));
         tasks.add(new SuccessAuth(userDB, done, "simple", "simple"));
         tasks.add(new InvalidAuth(userDB, done, "simple", "hacker"));
       }
@@ -102,7 +102,7 @@ public final class AuthLdapTest {
 
   @Test
   public void invalidUser() {
-    Assert.expectThrows(SVNAuthenticationException.class, () -> checkUser("ldapadmin2", "ldapadmin"));
+    Assert.expectThrows(SVNAuthenticationException.class, () -> checkUser("ldapadmin2", EmbeddedDirectoryServer.ADMIN_PASSWORD));
   }
 
   @Test

--- a/src/test/java/svnserver/ldap/EmbeddedDirectoryServer.java
+++ b/src/test/java/svnserver/ldap/EmbeddedDirectoryServer.java
@@ -27,6 +27,8 @@ import java.net.URL;
 public final class EmbeddedDirectoryServer implements AutoCloseable {
 
   @NotNull
+  static final String ADMIN_PASSWORD = "123456789012345678901234567890123456789012345678901234567890";
+  @NotNull
   private final InMemoryDirectoryServer server;
   @NotNull
   private final DN baseDn;
@@ -54,10 +56,9 @@ public final class EmbeddedDirectoryServer implements AutoCloseable {
     server.shutDown(true);
   }
 
-  @NotNull
-  public UserDBConfig createUserConfig() {
+  @NotNull UserDBConfig createUserConfig() {
     final LdapUserDBConfig config = new LdapUserDBConfig();
-    config.setBind(new LdapBindSimple(LdapBindSimple.BindType.Plain, "u:ldapadmin", "ldapadmin"));
+    config.setBind(new LdapBindSimple(LdapBindSimple.BindType.Plain, "u:ldapadmin", ADMIN_PASSWORD));
     config.setConnectionUrl("ldap://127.0.0.1:" + server.getListenPort() + "/" + baseDn);
     config.setSearchFilter("");
     config.setLoginAttribute("uid");

--- a/src/test/resources/svnserver/ldap/ldap.ldif
+++ b/src/test/resources/svnserver/ldap/ldap.ldif
@@ -20,7 +20,7 @@ objectclass: inetOrgPerson
 description: LDAP Administrator stuff
 givenName: LDAP Administrator
 uid: ldapadmin
-userPassword: ldapadmin
+userPassword: 123456789012345678901234567890123456789012345678901234567890
 mail: ldapadmin@mail.example.com
 entryUUID: ee24e04a-e2de-4446-be2d-e32e280f6f4e
 


### PR DESCRIPTION
Turns out, not all Base64 was born equal. RFC-4648 that we used,
only allows strict Base64 alphabet in input string while RFC-2045 also
allows whitespace, newlines and other funny stuff. And native Subversion
sends \n for long logins/passwords

Fixes #242