### PR TITLE
Allow latest Gitea to fail on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ addons:
     - gnome-doc-utils
 
 jobs:
+  allow_failures:
+    - env: GITEA_VERSION=latest
+
   include:
     # Gitlab
     - stage: test
@@ -55,7 +58,10 @@ jobs:
       env: GITEA_VERSION=latest
       jdk: oraclejdk8
     - stage: test
-      env: GITEA_VERSION=1.6
+      env: GITEA_VERSION=1.8 # Just latest release we pass tests against (as of 06 May 2019)
+      jdk: oraclejdk8
+    - stage: test
+      env: GITEA_VERSION=1.6 # The earliest Gitea version that git-as-svn can work with
       jdk: oraclejdk8
 
     # Different JDKs


### PR DESCRIPTION
Unfortunately, Gitea changes API from time to time and causes test breakages

Instead, add Gitea-1.8 to Travis matrix