### PR TITLE
Catastrophically speedup rename detection.

### DIFF
--- a/src/docs/asciidoc/_changelog.adoc
+++ b/src/docs/asciidoc/_changelog.adoc
@@ -6,6 +6,10 @@ ifdef::sectnums[]
 endif::[]
 :sectnums!:
 
+== Unreleased
+
+ * Catastrophically speedup rename detection (~50x). #306
+
 == 1.21.8
 
  * Write empty LFS files in a compatible with Git-LFS way

--- a/src/main/java/svnserver/repository/git/GitBranch.java
+++ b/src/main/java/svnserver/repository/git/GitBranch.java
@@ -13,6 +13,7 @@ import org.eclipse.jgit.lib.*;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.treewalk.filter.TreeFilter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mapdb.HTreeMap;
@@ -382,6 +383,7 @@ public final class GitBranch {
     }
     final TreeWalk tw = new TreeWalk(repository.getGit());
     tw.setRecursive(true);
+    tw.setFilter(TreeFilter.ANY_DIFF);
     tw.addTree(oldTreeId.getObject());
     tw.addTree(newTreeId.getObject());
 


### PR DESCRIPTION
Indexing `master` branch of [dotnet/coreclr](https://github.com/dotnet/coreclr) repository:

1. Without rename detection: 13.5 sec
2. With rename detection, before this commit: 13 *min*
3. With rename detection, after this commit: 19.5 sec

Fixes #306