### PR TITLE
Fix mess with svn:eol-style + svn:mime-type=application/octet-stream props

### DIFF
--- a/src/docs/asciidoc/_changelog.adoc
+++ b/src/docs/asciidoc/_changelog.adoc
@@ -15,6 +15,9 @@ endif::[]
 * git-as-svn no longer overrides `.gitattributes` settings with text/binary auto-detection
 * `svn:mime-type=application/octet-stream` property is now added to files that have `-text` in `.gitattributes`. https://github.com/bozaro/git-as-svn/issues/317[#317]
 
+IMPORTANT: Repository data exported to SVN has changed.
+Users will need to perform re-checkout of their working copies after git-as-svn upgrade.
+
 == 1.21.9
 
 * Catastrophically speedup rename detection (~50x). https://github.com/bozaro/git-as-svn/issues/306[#306]

--- a/src/docs/asciidoc/_changelog.adoc
+++ b/src/docs/asciidoc/_changelog.adoc
@@ -12,6 +12,8 @@ endif::[]
 * Update dependencies
 * `/usr/bin/git-as-svn` no longer implicitly adds `-Xmx512m` JVM argument
 * Several file descriptor leaks fixed
+* git-as-svn no longer overrides `.gitattributes` settings with text/binary auto-detection
+* `svn:mime-type=application/octet-stream` property is now added to files that have `-text` in `.gitattributes`. https://github.com/bozaro/git-as-svn/issues/317[#317]
 
 == 1.21.9
 

--- a/src/main/java/svnserver/repository/git/GitBranch.java
+++ b/src/main/java/svnserver/repository/git/GitBranch.java
@@ -36,6 +36,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public final class GitBranch {
   private static final int revisionCacheVersion = 2;
+  private static final int repositoryVersion = 2;
   private static final int REPORT_DELAY = 2500;
   private static final int MARK_NO_FILE = -1;
   @NotNull
@@ -78,7 +79,9 @@ public final class GitBranch {
     this.svnBranch = svnBranchRef.getName();
     this.gitBranch = Constants.R_HEADS + branch;
     final String repositoryId = loadRepositoryId(repository.getGit(), svnBranchRef);
-    this.uuid = UUID.nameUUIDFromBytes((repositoryId + "\0" + gitBranch).getBytes(StandardCharsets.UTF_8)).toString();
+    this.uuid = UUID.nameUUIDFromBytes(
+        String.format("%s\0%s\0%s", repositoryId, gitBranch, repositoryVersion).getBytes(StandardCharsets.UTF_8)
+    ).toString();
 
     final String revisionCacheName = String.format(
         "cache-revision.%s.%s.%s.v%s", repository.getContext().getName(), gitBranch, repository.hasRenameDetection() ? 1 : 0, revisionCacheVersion

--- a/src/main/java/svnserver/repository/git/GitFileEmptyTree.java
+++ b/src/main/java/svnserver/repository/git/GitFileEmptyTree.java
@@ -14,7 +14,6 @@ import org.jetbrains.annotations.Nullable;
 import svnserver.repository.VcsCopyFrom;
 import svnserver.repository.git.filter.GitFilter;
 import svnserver.repository.git.prop.GitProperty;
-import svnserver.repository.git.prop.PropertyMapping;
 
 import java.io.InputStream;
 import java.util.Collections;
@@ -31,7 +30,7 @@ final class GitFileEmptyTree extends GitEntryImpl implements GitFile {
   private final int revision;
 
   GitFileEmptyTree(@NotNull GitBranch branch, @NotNull String parentPath, int revision) {
-    super(PropertyMapping.getRootProperties(), parentPath, GitProperty.emptyArray, "", FileMode.TREE);
+    super(GitProperty.emptyArray, parentPath, GitProperty.emptyArray, "", FileMode.TREE);
     this.branch = branch;
     this.revision = revision;
   }

--- a/src/main/java/svnserver/repository/git/prop/GitAttributesFactory.java
+++ b/src/main/java/svnserver/repository/git/prop/GitAttributesFactory.java
@@ -15,7 +15,6 @@ import org.tmatesoft.svn.core.SVNProperty;
 import org.tmatesoft.svn.core.internal.wc.SVNFileUtil;
 import svnserver.Loggers;
 import svnserver.repository.git.path.Wildcard;
-import svnserver.repository.git.path.matcher.path.AlwaysMatcher;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,14 +62,6 @@ public final class GitAttributesFactory implements GitPropertyFactory {
     return properties.toArray(GitProperty.emptyArray);
   }
 
-  @NotNull
-  @Override
-  public GitProperty[] rootDefaults() {
-    return new GitProperty[]{
-        new GitFileProperty(AlwaysMatcher.INSTANCE, SVNProperty.EOL_STYLE, SVNProperty.EOL_STYLE_NATIVE)
-    };
-  }
-
   private static void processProperty(@NotNull List<GitProperty> properties, @NotNull Wildcard wildcard, @NotNull String property, @Nullable String value) {
     if (value == null) {
       return;
@@ -89,16 +80,13 @@ public final class GitAttributesFactory implements GitPropertyFactory {
   private String getMimeType(@NotNull String[] tokens) {
     for (int i = 1; i < tokens.length; ++i) {
       String token = tokens[i];
-      if (token.startsWith("binary")) {
+      if (token.equals("binary") || token.equals("-text"))
         return SVNFileUtil.BINARY_MIME_TYPE;
-      }
-      if (token.startsWith("-binary")) {
+
+      if (token.equals("text"))
         return "";
-      }
-      if (token.startsWith("text")) {
-        return "";
-      }
     }
+
     return null;
   }
 
@@ -118,12 +106,9 @@ public final class GitAttributesFactory implements GitPropertyFactory {
             return SVNProperty.EOL_STYLE_CRLF;
         }
       }
-      if (token.startsWith("binary")) {
+
+      if (token.equals("binary") || token.equals("-text"))
         return "";
-      }
-      if (token.startsWith("-text")) {
-        return "";
-      }
     }
     return null;
   }

--- a/src/main/java/svnserver/repository/git/prop/GitPropertyFactory.java
+++ b/src/main/java/svnserver/repository/git/prop/GitPropertyFactory.java
@@ -34,14 +34,4 @@ public interface GitPropertyFactory {
    * @return Git property workers.
    */
   @NotNull GitProperty[] create(@NotNull String content) throws IOException;
-
-  /**
-   * Create git property for root directory.
-   *
-   * @return Git property workers.
-   */
-  @NotNull
-  default GitProperty[] rootDefaults() {
-    return GitProperty.emptyArray;
-  }
 }

--- a/src/main/java/svnserver/repository/git/prop/PropertyMapping.java
+++ b/src/main/java/svnserver/repository/git/prop/PropertyMapping.java
@@ -11,7 +11,10 @@ import org.atteo.classindex.ClassIndex;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * @author Marat Radchenko <marat@slonopotamus.org>
@@ -19,29 +22,19 @@ import java.util.*;
 public final class PropertyMapping {
   @NotNull
   private static final Map<String, GitPropertyFactory> parserByFile = new TreeMap<>();
-  @NotNull
-  private static final GitProperty[] rootProperties;
 
   static {
     try {
-      GitProperty[] properties = GitProperty.emptyArray;
       for (Class<? extends GitPropertyFactory> factoryClass : ClassIndex.getSubclasses(GitPropertyFactory.class)) {
         final GitPropertyFactory factory = factoryClass.getConstructor().newInstance();
         final GitPropertyFactory oldParser = parserByFile.put(factory.getFileName(), factory);
         if (oldParser != null) {
           throw new RuntimeException("Found two classes mapped for same file: " + oldParser.getClass() + " and " + factoryClass);
         }
-        properties = GitProperty.joinProperties(properties, factory.rootDefaults());
       }
-      rootProperties = properties;
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  @NotNull
-  public static GitProperty[] getRootProperties() {
-    return Arrays.copyOf(rootProperties, rootProperties.length);
   }
 
   @Nullable

--- a/src/test/java/svnserver/ext/gitlfs/storage/local/LfsLocalStorageTest.java
+++ b/src/test/java/svnserver/ext/gitlfs/storage/local/LfsLocalStorageTest.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 import static svnserver.server.SvnFilePropertyTest.propsBinary;
+import static svnserver.server.SvnFilePropertyTest.propsEolNative;
 
 /**
  * Simple test for LfsLocalStorage.
@@ -66,7 +67,7 @@ public final class LfsLocalStorageTest {
   public void commitToLocalLFS() throws Exception {
     try (SvnTestServer server = SvnTestServer.createEmpty(null, false, SvnTestServer.LfsMode.Local)) {
       final SVNRepository svnRepository = server.openSvnRepository();
-      SvnTestHelper.createFile(svnRepository, ".gitattributes", "* -text\n*.txt filter=lfs diff=lfs merge=lfs -text", null);
+      SvnTestHelper.createFile(svnRepository, ".gitattributes", "* -text\n*.txt filter=lfs diff=lfs merge=lfs -text", propsBinary);
 
       final byte[] data = bigFile();
 
@@ -92,7 +93,7 @@ public final class LfsLocalStorageTest {
       Assert.assertNotNull(lock.getID());
       Assert.assertEquals(lock.getOwner(), SvnTestServer.USER_NAME);
 
-      SvnTestHelper.createFile(svnRepository, "empty.txt", GitRepository.emptyBytes, null);
+      SvnTestHelper.createFile(svnRepository, "empty.txt", GitRepository.emptyBytes, propsBinary);
       SvnTestHelper.checkFileContent(svnRepository, "empty.txt", GitRepository.emptyBytes);
     }
   }

--- a/src/test/java/svnserver/ext/gitlfs/storage/network/LfsHttpStorageTest.java
+++ b/src/test/java/svnserver/ext/gitlfs/storage/network/LfsHttpStorageTest.java
@@ -97,7 +97,7 @@ public final class LfsHttpStorageTest {
 
       try (SvnTestServer server = SvnTestServer.createEmpty(null, false, SvnTestServer.LfsMode.None, new GitAsSvnLfsHttpStorage(url, user))) {
         final SVNRepository svnRepository = server.openSvnRepository();
-        SvnTestHelper.createFile(svnRepository, ".gitattributes", "* -text\n*.txt filter=lfs diff=lfs merge=lfs -text", null);
+        SvnTestHelper.createFile(svnRepository, ".gitattributes", "* -text\n*.txt filter=lfs diff=lfs merge=lfs -text", propsBinary);
 
         final byte[] data = LfsLocalStorageTest.bigFile();
 

--- a/src/test/java/svnserver/repository/git/prop/GitEolTest.java
+++ b/src/test/java/svnserver/repository/git/prop/GitEolTest.java
@@ -28,31 +28,31 @@ import java.util.TreeMap;
 public final class GitEolTest {
   @DataProvider(name = "parseAttributesData")
   public static Object[][] parseAttributesData() {
-    final GitProperty[] attr = GitProperty.joinProperties(
-        new GitAttributesFactory().rootDefaults(),
-        new GitAttributesFactory().create(
-            "# comment\n" +
-                "*.txt  eol=native\n" +
-                "*.md   eol=lf\n" +
-                "*.dat  -text\n" +
-                "3.md   -text\n" +
-                "*.bin  binary\n" +
-                "1.bin  -binary\n" +
-                "2.bin  text\n"
-        )
+    final GitProperty[] attr = new GitAttributesFactory().create(
+        "# comment\n" +
+            "* text eol=native\n" +
+            "*.txt text eol=native\n" +
+            "*.md  text eol=lf\n" +
+            "*.dat -text\n" +
+            "3.md -text\n" +
+            "*.bin binary\n" +
+            "1.bin text\n" +
+            "2.bin text\n"
     );
     final Params[] params = new Params[]{
         new Params(attr, "/").prop(SVNProperty.INHERITABLE_AUTO_PROPS, "*.txt = svn:eol-style=native\n" +
             "*.md = svn:eol-style=LF\n" +
+            "*.dat = svn:mime-type=application/octet-stream\n" +
+            "3.md = svn:mime-type=application/octet-stream\n" +
             "*.bin = svn:mime-type=application/octet-stream\n"),
         new Params(attr, "README.md").prop(SVNProperty.EOL_STYLE, SVNProperty.EOL_STYLE_LF),
-        new Params(attr, "foo.dat"),
+        new Params(attr, "foo.dat").prop(SVNProperty.MIME_TYPE, SVNFileUtil.BINARY_MIME_TYPE),
         new Params(attr, "foo.txt").prop(SVNProperty.EOL_STYLE, SVNProperty.EOL_STYLE_NATIVE),
         new Params(attr, "foo.bin").prop(SVNProperty.MIME_TYPE, SVNFileUtil.BINARY_MIME_TYPE),
 
         new Params(attr, "1.bin"),
         new Params(attr, "2.bin"),
-        new Params(attr, "3.md"),
+        new Params(attr, "3.md").prop(SVNProperty.MIME_TYPE, SVNFileUtil.BINARY_MIME_TYPE),
 
         new Params(attr, "changelog").prop(SVNProperty.EOL_STYLE, SVNProperty.EOL_STYLE_NATIVE),
     };

--- a/src/test/java/svnserver/server/DepthTest.java
+++ b/src/test/java/svnserver/server/DepthTest.java
@@ -14,6 +14,7 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.tmatesoft.svn.core.SVNDepth;
 import org.tmatesoft.svn.core.SVNException;
+import org.tmatesoft.svn.core.SVNProperty;
 import org.tmatesoft.svn.core.SVNPropertyValue;
 import org.tmatesoft.svn.core.io.ISVNEditor;
 import org.tmatesoft.svn.core.io.ISVNReporterBaton;
@@ -65,6 +66,7 @@ public final class DepthTest {
           "a/b/c/d - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/c/d - change-file-prop: svn:entry:last-author\n" +
           "a/b/c/d - change-file-prop: svn:entry:uuid\n" +
+          "a/b/c/d - change-file-prop: svn:eol-style\n" +
           "a/b/c/d - close-file: e08b5cff98d6e3f8a892fc999622d441\n" +
           "a/b/c/d - delta-chunk\n" +
           "a/b/c/d - delta-end\n");
@@ -82,20 +84,24 @@ public final class DepthTest {
     editor.changeDirProperty("svn:ignore", SVNPropertyValue.create("sample.txt"));
 
     editor.addFile("/.gitattributes", null, -1);
-    sendDeltaAndClose(editor, "/.gitattributes", null, "* -text\n");
+    editor.changeFileProperty("/.gitattributes", SVNProperty.EOL_STYLE, SVNPropertyValue.create(SVNProperty.EOL_STYLE_NATIVE));
+    sendDeltaAndClose(editor, "/.gitattributes", null, "\n");
 
     editor.addFile("/.gitignore", null, -1);
+    editor.changeFileProperty("/.gitignore", SVNProperty.EOL_STYLE, SVNPropertyValue.create(SVNProperty.EOL_STYLE_NATIVE));
     sendDeltaAndClose(editor, "/.gitignore", null, "/sample.txt\n");
 
     editor.addDir("/a", null, -1);
     editor.addDir("/a/b", null, -1);
 
     editor.addFile("/a/b/e", null, -1);
+    editor.changeFileProperty("/a/b/e", SVNProperty.EOL_STYLE, SVNPropertyValue.create(SVNProperty.EOL_STYLE_NATIVE));
     sendDeltaAndClose(editor, "/a/b/e", null, "e body");
 
     editor.addDir("/a/b/c", null, -1);
 
     editor.addFile("/a/b/c/d", null, -1);
+    editor.changeFileProperty("/a/b/c/d", SVNProperty.EOL_STYLE, SVNPropertyValue.create(SVNProperty.EOL_STYLE_NATIVE));
     sendDeltaAndClose(editor, "/a/b/c/d", null, "d body");
 
     editor.closeDir();
@@ -150,7 +156,8 @@ public final class DepthTest {
           ".gitattributes - change-file-prop: svn:entry:committed-rev\n" +
           ".gitattributes - change-file-prop: svn:entry:last-author\n" +
           ".gitattributes - change-file-prop: svn:entry:uuid\n" +
-          ".gitattributes - close-file: d3d04ac1b5897688b0d97abfd135aefa\n" +
+          ".gitattributes - change-file-prop: svn:eol-style\n" +
+          ".gitattributes - close-file: 68b329da9893e34099c7d8ad5cb9c940\n" +
           ".gitattributes - delta-chunk\n" +
           ".gitattributes - delta-end\n" +
           ".gitignore - add-file\n" +
@@ -159,6 +166,7 @@ public final class DepthTest {
           ".gitignore - change-file-prop: svn:entry:committed-rev\n" +
           ".gitignore - change-file-prop: svn:entry:last-author\n" +
           ".gitignore - change-file-prop: svn:entry:uuid\n" +
+          ".gitignore - change-file-prop: svn:eol-style\n" +
           ".gitignore - close-file: 57457451fdf67806102d334f30c062f3\n" +
           ".gitignore - delta-chunk\n" +
           ".gitignore - delta-end\n" +
@@ -187,6 +195,7 @@ public final class DepthTest {
           "a/b/c/d - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/c/d - change-file-prop: svn:entry:last-author\n" +
           "a/b/c/d - change-file-prop: svn:entry:uuid\n" +
+          "a/b/c/d - change-file-prop: svn:eol-style\n" +
           "a/b/c/d - close-file: e08b5cff98d6e3f8a892fc999622d441\n" +
           "a/b/c/d - delta-chunk\n" +
           "a/b/c/d - delta-end\n" +
@@ -196,6 +205,7 @@ public final class DepthTest {
           "a/b/e - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/e - change-file-prop: svn:entry:last-author\n" +
           "a/b/e - change-file-prop: svn:entry:uuid\n" +
+          "a/b/e - change-file-prop: svn:eol-style\n" +
           "a/b/e - close-file: babc2f91dac8ef35815e635d89196696\n" +
           "a/b/e - delta-chunk\n" +
           "a/b/e - delta-end\n");
@@ -244,6 +254,7 @@ public final class DepthTest {
           "a/b/c/d - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/c/d - change-file-prop: svn:entry:last-author\n" +
           "a/b/c/d - change-file-prop: svn:entry:uuid\n" +
+          "a/b/c/d - change-file-prop: svn:eol-style\n" +
           "a/b/c/d - close-file: e08b5cff98d6e3f8a892fc999622d441\n" +
           "a/b/c/d - delta-chunk\n" +
           "a/b/c/d - delta-end\n" +
@@ -253,6 +264,7 @@ public final class DepthTest {
           "a/b/e - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/e - change-file-prop: svn:entry:last-author\n" +
           "a/b/e - change-file-prop: svn:entry:uuid\n" +
+          "a/b/e - change-file-prop: svn:eol-style\n" +
           "a/b/e - close-file: babc2f91dac8ef35815e635d89196696\n" +
           "a/b/e - delta-chunk\n" +
           "a/b/e - delta-end\n");
@@ -296,6 +308,7 @@ public final class DepthTest {
           "a/b/c/d - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/c/d - change-file-prop: svn:entry:last-author\n" +
           "a/b/c/d - change-file-prop: svn:entry:uuid\n" +
+          "a/b/c/d - change-file-prop: svn:eol-style\n" +
           "a/b/c/d - close-file: e08b5cff98d6e3f8a892fc999622d441\n" +
           "a/b/c/d - delta-chunk\n" +
           "a/b/c/d - delta-end\n");
@@ -317,7 +330,8 @@ public final class DepthTest {
           ".gitattributes - change-file-prop: svn:entry:committed-rev\n" +
           ".gitattributes - change-file-prop: svn:entry:last-author\n" +
           ".gitattributes - change-file-prop: svn:entry:uuid\n" +
-          ".gitattributes - close-file: d3d04ac1b5897688b0d97abfd135aefa\n" +
+          ".gitattributes - change-file-prop: svn:eol-style\n" +
+          ".gitattributes - close-file: 68b329da9893e34099c7d8ad5cb9c940\n" +
           ".gitattributes - delta-chunk\n" +
           ".gitattributes - delta-end\n" +
           ".gitignore - add-file\n" +
@@ -326,6 +340,7 @@ public final class DepthTest {
           ".gitignore - change-file-prop: svn:entry:committed-rev\n" +
           ".gitignore - change-file-prop: svn:entry:last-author\n" +
           ".gitignore - change-file-prop: svn:entry:uuid\n" +
+          ".gitignore - change-file-prop: svn:eol-style\n" +
           ".gitignore - close-file: 57457451fdf67806102d334f30c062f3\n" +
           ".gitignore - delta-chunk\n" +
           ".gitignore - delta-end\n" +
@@ -355,6 +370,7 @@ public final class DepthTest {
           "a/b/c/d - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/c/d - change-file-prop: svn:entry:last-author\n" +
           "a/b/c/d - change-file-prop: svn:entry:uuid\n" +
+          "a/b/c/d - change-file-prop: svn:eol-style\n" +
           "a/b/c/d - close-file: e08b5cff98d6e3f8a892fc999622d441\n" +
           "a/b/c/d - delta-chunk\n" +
           "a/b/c/d - delta-end\n" +
@@ -364,6 +380,7 @@ public final class DepthTest {
           "a/b/e - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/e - change-file-prop: svn:entry:last-author\n" +
           "a/b/e - change-file-prop: svn:entry:uuid\n" +
+          "a/b/e - change-file-prop: svn:eol-style\n" +
           "a/b/e - close-file: babc2f91dac8ef35815e635d89196696\n" +
           "a/b/e - delta-chunk\n" +
           "a/b/e - delta-end\n");
@@ -410,6 +427,7 @@ public final class DepthTest {
           "a/b/c/d - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/c/d - change-file-prop: svn:entry:last-author\n" +
           "a/b/c/d - change-file-prop: svn:entry:uuid\n" +
+          "a/b/c/d - change-file-prop: svn:eol-style\n" +
           "a/b/c/d - close-file: e08b5cff98d6e3f8a892fc999622d441\n" +
           "a/b/c/d - delta-chunk\n" +
           "a/b/c/d - delta-end\n" +
@@ -419,6 +437,7 @@ public final class DepthTest {
           "a/b/e - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/e - change-file-prop: svn:entry:last-author\n" +
           "a/b/e - change-file-prop: svn:entry:uuid\n" +
+          "a/b/e - change-file-prop: svn:eol-style\n" +
           "a/b/e - close-file: babc2f91dac8ef35815e635d89196696\n" +
           "a/b/e - delta-chunk\n" +
           "a/b/e - delta-end\n");
@@ -451,6 +470,7 @@ public final class DepthTest {
           "a/b/e - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/e - change-file-prop: svn:entry:last-author\n" +
           "a/b/e - change-file-prop: svn:entry:uuid\n" +
+          "a/b/e - change-file-prop: svn:eol-style\n" +
           "a/b/e - close-file: babc2f91dac8ef35815e635d89196696\n" +
           "a/b/e - delta-chunk\n" +
           "a/b/e - delta-end\n");
@@ -482,6 +502,7 @@ public final class DepthTest {
           "a/b/c/d - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/c/d - change-file-prop: svn:entry:last-author\n" +
           "a/b/c/d - change-file-prop: svn:entry:uuid\n" +
+          "a/b/c/d - change-file-prop: svn:eol-style\n" +
           "a/b/c/d - close-file: e08b5cff98d6e3f8a892fc999622d441\n" +
           "a/b/c/d - delta-chunk\n" +
           "a/b/c/d - delta-end\n");
@@ -513,6 +534,7 @@ public final class DepthTest {
           "a/b/e - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/e - change-file-prop: svn:entry:last-author\n" +
           "a/b/e - change-file-prop: svn:entry:uuid\n" +
+          "a/b/e - change-file-prop: svn:eol-style\n" +
           "a/b/e - close-file: babc2f91dac8ef35815e635d89196696\n" +
           "a/b/e - delta-chunk\n" +
           "a/b/e - delta-end\n");
@@ -544,6 +566,7 @@ public final class DepthTest {
           "a/b/c/d - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/c/d - change-file-prop: svn:entry:last-author\n" +
           "a/b/c/d - change-file-prop: svn:entry:uuid\n" +
+          "a/b/c/d - change-file-prop: svn:eol-style\n" +
           "a/b/c/d - close-file: e08b5cff98d6e3f8a892fc999622d441\n" +
           "a/b/c/d - delta-chunk\n" +
           "a/b/c/d - delta-end\n");
@@ -565,7 +588,8 @@ public final class DepthTest {
           ".gitattributes - change-file-prop: svn:entry:committed-rev\n" +
           ".gitattributes - change-file-prop: svn:entry:last-author\n" +
           ".gitattributes - change-file-prop: svn:entry:uuid\n" +
-          ".gitattributes - close-file: d3d04ac1b5897688b0d97abfd135aefa\n" +
+          ".gitattributes - change-file-prop: svn:eol-style\n" +
+          ".gitattributes - close-file: 68b329da9893e34099c7d8ad5cb9c940\n" +
           ".gitattributes - delta-chunk\n" +
           ".gitattributes - delta-end\n" +
           ".gitignore - add-file\n" +
@@ -574,6 +598,7 @@ public final class DepthTest {
           ".gitignore - change-file-prop: svn:entry:committed-rev\n" +
           ".gitignore - change-file-prop: svn:entry:last-author\n" +
           ".gitignore - change-file-prop: svn:entry:uuid\n" +
+          ".gitignore - change-file-prop: svn:eol-style\n" +
           ".gitignore - close-file: 57457451fdf67806102d334f30c062f3\n" +
           ".gitignore - delta-chunk\n" +
           ".gitignore - delta-end\n" +
@@ -603,6 +628,7 @@ public final class DepthTest {
           "a/b/c/d - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/c/d - change-file-prop: svn:entry:last-author\n" +
           "a/b/c/d - change-file-prop: svn:entry:uuid\n" +
+          "a/b/c/d - change-file-prop: svn:eol-style\n" +
           "a/b/c/d - close-file: e08b5cff98d6e3f8a892fc999622d441\n" +
           "a/b/c/d - delta-chunk\n" +
           "a/b/c/d - delta-end\n" +
@@ -612,6 +638,7 @@ public final class DepthTest {
           "a/b/e - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/e - change-file-prop: svn:entry:last-author\n" +
           "a/b/e - change-file-prop: svn:entry:uuid\n" +
+          "a/b/e - change-file-prop: svn:eol-style\n" +
           "a/b/e - close-file: babc2f91dac8ef35815e635d89196696\n" +
           "a/b/e - delta-chunk\n" +
           "a/b/e - delta-end\n");
@@ -653,6 +680,7 @@ public final class DepthTest {
           "a/b/c/d - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/c/d - change-file-prop: svn:entry:last-author\n" +
           "a/b/c/d - change-file-prop: svn:entry:uuid\n" +
+          "a/b/c/d - change-file-prop: svn:eol-style\n" +
           "a/b/c/d - close-file: e08b5cff98d6e3f8a892fc999622d441\n" +
           "a/b/c/d - delta-chunk\n" +
           "a/b/c/d - delta-end\n");
@@ -694,6 +722,7 @@ public final class DepthTest {
           "a/b/c/d - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/c/d - change-file-prop: svn:entry:last-author\n" +
           "a/b/c/d - change-file-prop: svn:entry:uuid\n" +
+          "a/b/c/d - change-file-prop: svn:eol-style\n" +
           "a/b/c/d - close-file: e08b5cff98d6e3f8a892fc999622d441\n" +
           "a/b/c/d - delta-chunk\n" +
           "a/b/c/d - delta-end\n" +
@@ -703,6 +732,7 @@ public final class DepthTest {
           "a/b/e - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/e - change-file-prop: svn:entry:last-author\n" +
           "a/b/e - change-file-prop: svn:entry:uuid\n" +
+          "a/b/e - change-file-prop: svn:eol-style\n" +
           "a/b/e - close-file: babc2f91dac8ef35815e635d89196696\n" +
           "a/b/e - delta-chunk\n" +
           "a/b/e - delta-end\n");
@@ -745,6 +775,7 @@ public final class DepthTest {
           "a/b/c/d - change-file-prop: svn:entry:committed-rev\n" +
           "a/b/c/d - change-file-prop: svn:entry:last-author\n" +
           "a/b/c/d - change-file-prop: svn:entry:uuid\n" +
+          "a/b/c/d - change-file-prop: svn:eol-style\n" +
           "a/b/c/d - close-file: e08b5cff98d6e3f8a892fc999622d441\n" +
           "a/b/c/d - delta-chunk\n" +
           "a/b/c/d - delta-end\n");

--- a/src/test/java/svnserver/server/SvnFilePropertyTest.java
+++ b/src/test/java/svnserver/server/SvnFilePropertyTest.java
@@ -59,6 +59,7 @@ public final class SvnFilePropertyTest {
   @NotNull
   private final static Map<String, String> propsNeedsLock = ImmutableMap.<String, String>builder()
       .put(SVNProperty.NEEDS_LOCK, "*")
+      .put(SVNProperty.MIME_TYPE, SVNFileUtil.BINARY_MIME_TYPE)
       .build();
 
   /**


### PR DESCRIPTION
Now we add `svn:mime-type=application/octet-stream` for files with `-text` git attributes

Also, we no longer override explicit `.gitattributes` entries with binary file autodetection.

Fixes #317