### PR TITLE
Fixes to eol git attribute handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*			-text
-*.bat			text eol=native
+* -text
+*.bat text

--- a/src/docs/asciidoc/_changelog.adoc
+++ b/src/docs/asciidoc/_changelog.adoc
@@ -6,6 +6,16 @@ ifdef::sectnums[]
 endif::[]
 :sectnums!:
 
+== Unreleased
+
+* Drop support for nonstandard `eol=cr` in `.gitattributes` with no replacement
+* Drop support for nonstandard `eol=native` in `.gitattributes`.
+Just add `text` attribute to indicate that file has native EOLs.
+* JGit is now used to parse `.gitattributes` files
+
+IMPORTANT: Repository data exported to SVN has changed.
+Users will need to perform re-checkout of their working copies after git-as-svn upgrade.
+
 == 1.22.0
 
 * Systemd unit now correctly waits for git-as-svn to shut down. https://github.com/bozaro/git-as-svn/issues/275[#275]

--- a/src/docs/asciidoc/_props.adoc
+++ b/src/docs/asciidoc/_props.adoc
@@ -72,8 +72,8 @@ This file affects the properties of the `svn:eol-style` and `svn:mime-type` file
 For example, a file with contents:
 
 ----
-*.txt           text eol=native
-*.xml           eol=lf
+*.txt           text
+*.xml           text eol=lf
 *.bin           binary
 ----
 
@@ -87,7 +87,7 @@ Add property to the directory `svn:auto-props` with the contents:
 
 And files in this directory:
 
-* for suffix `.txt` add property `svn:eol-style = navtive`
+* for suffix `.txt` add property `svn:eol-style = native`
 * for suffix `.xml` add property `svn:eol-style = LF`
 * for suffix `.bin` add property
 `svn:mime-type = application/octet-stream`
@@ -107,8 +107,7 @@ Properties are mapped one-to-one, for example, a file with the contents:
 
 It will be converted to properties:
 
-* `bugtraq:url =
-        https://github.com/bozaro/git-as-svn/issues/%BUGID%`
+* `bugtraq:url = https://github.com/bozaro/git-as-svn/issues/%BUGID%`
 * `bugtraq:logregex = #(\\d+)`
 * `bugtraq:warnifnoissue = false`
 

--- a/src/main/java/svnserver/repository/git/GitBranch.java
+++ b/src/main/java/svnserver/repository/git/GitBranch.java
@@ -36,7 +36,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public final class GitBranch {
   private static final int revisionCacheVersion = 2;
-  private static final int repositoryVersion = 2;
+  private static final int repositoryVersion = 3;
   private static final int REPORT_DELAY = 2500;
   private static final int MARK_NO_FILE = -1;
   @NotNull

--- a/src/main/java/svnserver/repository/git/GitFileTreeEntry.java
+++ b/src/main/java/svnserver/repository/git/GitFileTreeEntry.java
@@ -130,7 +130,7 @@ final class GitFileTreeEntry extends GitEntryImpl implements GitFile {
         if (branch.getRepository().isObjectBinary(filter, getObjectId())) {
           props.put(SVNProperty.MIME_TYPE, MIME_BINARY);
         } else {
-          props.put(SVNProperty.EOL_STYLE, SVNProperty.NATIVE);
+          props.put(SVNProperty.EOL_STYLE, SVNProperty.EOL_STYLE_NATIVE);
         }
       }
     }

--- a/src/main/java/svnserver/repository/git/prop/GitIgnoreFactory.java
+++ b/src/main/java/svnserver/repository/git/prop/GitIgnoreFactory.java
@@ -9,6 +9,9 @@ package svnserver.repository.git.prop;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 /**
  * Factory for creating .gitignore properties.
  *
@@ -24,9 +27,9 @@ public final class GitIgnoreFactory implements GitPropertyFactory {
 
   @NotNull
   @Override
-  public GitProperty[] create(@NotNull String content) {
+  public GitProperty[] create(@NotNull InputStream stream) throws IOException {
     return new GitProperty[]{
-        new GitIgnore(content)
+        GitIgnore.parseConfig(stream)
     };
   }
 }

--- a/src/main/java/svnserver/repository/git/prop/GitProperty.java
+++ b/src/main/java/svnserver/repository/git/prop/GitProperty.java
@@ -20,6 +20,7 @@ import java.util.Map;
  * @author Artem V. Navrotskiy <bozaro@users.noreply.github.com>
  */
 public interface GitProperty {
+  @NotNull
   GitProperty[] emptyArray = {};
 
   /**
@@ -44,20 +45,6 @@ public interface GitProperty {
    * @return Filter name.
    */
   @Nullable String getFilterName();
-
-  @NotNull
-  static GitProperty[] joinProperties(@NotNull GitProperty[] before, @NotNull GitProperty[] after) {
-    if (before.length == 0) {
-      return after;
-    }
-    if (after.length == 0) {
-      return before;
-    }
-    final GitProperty[] joined = new GitProperty[before.length + after.length];
-    System.arraycopy(before, 0, joined, 0, before.length);
-    System.arraycopy(after, 0, joined, before.length, after.length);
-    return joined;
-  }
 
   @NotNull
   static GitProperty[] joinProperties(@NotNull GitProperty[] parentProps, @NotNull String entryName, @NotNull FileMode fileMode, @NotNull GitProperty[] entryProps) {

--- a/src/main/java/svnserver/repository/git/prop/GitPropertyFactory.java
+++ b/src/main/java/svnserver/repository/git/prop/GitPropertyFactory.java
@@ -11,6 +11,7 @@ import org.atteo.classindex.IndexSubclasses;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Factory for creating GitProperty.
@@ -30,8 +31,8 @@ public interface GitPropertyFactory {
   /**
    * Create git property worker by file content.
    *
-   * @param content File content.
+   * @param stream File content.
    * @return Git property workers.
    */
-  @NotNull GitProperty[] create(@NotNull String content) throws IOException;
+  @NotNull GitProperty[] create(@NotNull InputStream stream) throws IOException;
 }

--- a/src/test/java/svnserver/TestHelper.java
+++ b/src/test/java/svnserver/TestHelper.java
@@ -8,6 +8,7 @@
 package svnserver;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.input.CharSequenceInputStream;
 import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryDescription;
 import org.eclipse.jgit.internal.storage.dfs.InMemoryRepository;
 import org.eclipse.jgit.lib.Repository;
@@ -16,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -57,6 +59,11 @@ public final class TestHelper {
 
   public static void deleteDirectory(@NotNull Path file) throws IOException {
     FileUtils.deleteDirectory(file.toFile());
+  }
+
+  @NotNull
+  public static InputStream asStream(@NotNull String content) {
+    return new CharSequenceInputStream(content, StandardCharsets.UTF_8);
   }
 
   @NotNull

--- a/src/test/java/svnserver/repository/git/prop/GitIgnoreTest.java
+++ b/src/test/java/svnserver/repository/git/prop/GitIgnoreTest.java
@@ -12,7 +12,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import svnserver.TestHelper;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,8 +26,9 @@ import java.util.Map;
  */
 public final class GitIgnoreTest {
   @Test
-  public void testParseAttributes() {
-    final GitProperty attr = new GitIgnore(
+  public void testParseAttributes() throws IOException {
+    final GitProperty attr;
+    try (InputStream in = TestHelper.asStream(
         "# comment\n" +
             "*.class\n" +
             "\\#*\n" +
@@ -36,8 +40,9 @@ public final class GitIgnoreTest {
             "**/temp\n" +
             "**/foo/bar\n" +
             "qqq/**/bar\n" +
-            "data/**/*.sample\n"
-    );
+            "data/**/*.sample\n")) {
+      attr = GitIgnore.parseConfig(in);
+    }
     checkProps(attr, ".idea\ndeploy\n", "*.class\n#*\nspace end \ntemp\n");
     // Rule: */.idea/vcs.xml
     checkProps(attr, "build\n", null, ".idea\ndeploy");

--- a/src/test/java/svnserver/repository/git/prop/GitTortoiseTest.java
+++ b/src/test/java/svnserver/repository/git/prop/GitTortoiseTest.java
@@ -9,8 +9,10 @@ package svnserver.repository.git.prop;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import svnserver.TestHelper;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,12 +24,15 @@ import java.util.Map;
 public final class GitTortoiseTest {
   @Test
   public void testParseAttributes() throws IOException {
-    final GitProperty attr = new GitTortoise(
+    final GitProperty attr;
+    try (InputStream in = TestHelper.asStream(
         "[bugtraq]\n" +
             "\turl = http://bugtracking/browse/%BUGID%\n" +
             "\tlogregex = (BUG-\\\\d+)\n" +
             "\twarnifnoissue = false"
-    );
+    )) {
+      attr = GitTortoise.parseConfig(in);
+    }
     final Map<String, String> props = new HashMap<>();
     attr.apply(props);
     Assert.assertEquals(props.size(), 3);
@@ -38,7 +43,8 @@ public final class GitTortoiseTest {
 
   @Test
   public void testTortoiseAttributes() throws IOException {
-    final GitProperty attr = new GitTortoise(
+    final GitProperty attr;
+    try (InputStream in = TestHelper.asStream(
         "[bugtraq]\n" +
             "\turl = https://tortoisegit.org/issue/%BUGID%\n" +
             "\tlogregex = \"[Ii]ssues?:?(\\\\s*(,|and)?\\\\s*#?\\\\d+)+\\n(\\\\d+)\"\n" +
@@ -48,7 +54,9 @@ public final class GitTortoiseTest {
             "\twarnnosignedoffby = true\n" +
             "\tprojectlanguage = 1033\n" +
             "\ticon = src/Resources/Tortoise.ico"
-    );
+    )) {
+      attr = GitTortoise.parseConfig(in);
+    }
     final Map<String, String> props = new HashMap<>();
     attr.apply(props);
     Assert.assertEquals(props.size(), 6);

--- a/src/test/java/svnserver/server/SvnFilePropertyTest.java
+++ b/src/test/java/svnserver/server/SvnFilePropertyTest.java
@@ -325,7 +325,7 @@ public final class SvnFilePropertyTest {
       final String filePath = "/foo/.gitattributes";
       editor.addFile(filePath, null, -1);
       editor.changeFileProperty(filePath, SVNProperty.EOL_STYLE, SVNPropertyValue.create(SVNProperty.EOL_STYLE_NATIVE));
-      sendDeltaAndClose(editor, filePath, null, "*.txt\t\t\ttext eol=native\n");
+      sendDeltaAndClose(editor, filePath, null, "*.txt\t\t\ttext\n");
       // Close dir
       editor.closeDir();
       editor.closeDir();
@@ -348,7 +348,7 @@ public final class SvnFilePropertyTest {
         // Empty file.
         final String filePath = "/foo/.gitattributes";
         editor.addFile(filePath, null, -1);
-        sendDeltaAndClose(editor, filePath, null, "*.txt\t\t\ttext eol=native\n");
+        sendDeltaAndClose(editor, filePath, null, "*.txt\t\t\ttext\n");
         // Close dir
         editor.closeDir();
         editor.closeDir();
@@ -390,7 +390,7 @@ public final class SvnFilePropertyTest {
         // Empty file.
         final String filePath = "/foo/.gitattributes";
         editor.openFile(filePath, latestRevision);
-        sendDeltaAndClose(editor, filePath, "", "*.txt\t\t\ttext eol=native\n");
+        sendDeltaAndClose(editor, filePath, "", "*.txt\t\t\ttext\n");
         // Close dir
         editor.closeDir();
         editor.closeDir();
@@ -428,7 +428,7 @@ public final class SvnFilePropertyTest {
         // Empty file.
         final String filePath = "/foo/.gitattributes";
         editor.openFile(filePath, latestRevision);
-        sendDeltaAndClose(editor, filePath, "", "*.txt\t\t\ttext eol=native\n");
+        sendDeltaAndClose(editor, filePath, "", "*.txt\t\t\ttext\n");
         // Close dir
         editor.closeDir();
         editor.closeDir();
@@ -457,7 +457,7 @@ public final class SvnFilePropertyTest {
         // Empty file.
         final String filePath = "/.gitattributes";
         editor.openFile(filePath, latestRevision);
-        sendDeltaAndClose(editor, filePath, "", "*.txt\t\t\ttext eol=native\n");
+        sendDeltaAndClose(editor, filePath, "", "*.txt\t\t\ttext\n");
         // Close dir
         editor.closeDir();
         editor.closeEdit();
@@ -481,7 +481,7 @@ public final class SvnFilePropertyTest {
         // Empty file.
         final String filePath = "/.gitattributes";
         editor.openFile(filePath, latestRevision);
-        sendDeltaAndClose(editor, filePath, "", "*.txt\t\t\ttext eol=native\n");
+        sendDeltaAndClose(editor, filePath, "", "*.txt\t\t\ttext\n");
         // Close dir
         editor.closeDir();
         editor.closeEdit();


### PR DESCRIPTION
* Drop support for nonstandard `eol=cr` in `.gitattributes` with no replacement
* Drop support for nonstandard `eol=native` in `.gitattributes`
Just add `text` attribute to indicate that file has native EOLs.
* JGit is now used to parse `.gitattributes` files