### PR TITLE
resolves #326 fix GitLabIntegrationTest#gitlabMappingAsRoot with GitLab >= 12.7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
   include:
     # Gitlab
     - stage: test
-      env: GITLAB_VERSION=12.6.4-ce.0
+      env: GITLAB_VERSION=latest
       jdk: &oldest_jdk openjdk8
     - stage: test
       env: GITLAB_VERSION=11.0.3-ce.0 # Gitlab >= 11.0 no longer has API v3 (issue #176)

--- a/src/test/java/svnserver/ext/gitlab/GitLabIntegrationTest.java
+++ b/src/test/java/svnserver/ext/gitlab/GitLabIntegrationTest.java
@@ -105,7 +105,11 @@ public final class GitLabIntegrationTest {
 
     final GitlabAPI rootAPI = GitLabContext.connect(gitlabUrl, rootToken);
 
-    final GitlabUser gitlabUser = rootAPI.createUser(new CreateUserRequest(user, user, "git-as-svn@localhost").setPassword(userPassword));
+    final CreateUserRequest createUserRequest = new CreateUserRequest(user, user, "git-as-svn@localhost")
+        .setPassword(userPassword)
+        .setSkipConfirmation(true);
+
+    final GitlabUser gitlabUser = rootAPI.createUser(createUserRequest);
     Assert.assertNotNull(gitlabUser);
 
     final GitlabGroup group = rootAPI.createGroup(new CreateGroupRequest("testGroup").setVisibility(GitlabVisibility.PUBLIC), null);


### PR DESCRIPTION
Due to fix of CVE-2020-7972, user with unconfirmed email cannot get OAuth token anymore.

Workaround this by creating user with skipConfirmation=true

GitLab CVE- info: https://about.gitlab.com/releases/2020/01/30/security-release-gitlab-12-7-4-released/#email-confirmation-bypass-using-api