### PR TITLE
Propagate user info to GitLab LFS

### DIFF
--- a/src/docs/asciidoc/_changelog.adoc
+++ b/src/docs/asciidoc/_changelog.adoc
@@ -6,6 +6,10 @@ ifdef::sectnums[]
 endif::[]
 :sectnums!:
 
+== Unreleased
+
+* Fix a bug that caused Git-LFS locks in GitLab to be created on behalf of administator user instead of the user who locks file through git-as-svn
+
 == 1.23.1
 
 * Fix "Malformed network data" error for `svn blame`

--- a/src/main/java/svnserver/auth/ACL.java
+++ b/src/main/java/svnserver/auth/ACL.java
@@ -311,7 +311,7 @@ public final class ACL implements VcsAccess {
 
     @Override
     public boolean matches(@NotNull User user) {
-      return !user.isAnonymous() && user.getUserName().equals(this.user);
+      return !user.isAnonymous() && user.getUsername().equals(this.user);
     }
 
     @Override
@@ -341,7 +341,7 @@ public final class ACL implements VcsAccess {
       if (authenticatedGroups.getOrDefault(user.getType(), Collections.emptySet()).contains(group))
         return true;
 
-      return user2groups.getOrDefault(user.getUserName(), Collections.emptySet()).contains(group);
+      return user2groups.getOrDefault(user.getUsername(), Collections.emptySet()).contains(group);
     }
 
     @Override

--- a/src/main/java/svnserver/auth/LocalUserDB.java
+++ b/src/main/java/svnserver/auth/LocalUserDB.java
@@ -32,13 +32,13 @@ public final class LocalUserDB implements UserDB {
   }
 
   @Nullable
-  public User add(@NotNull String userName, @NotNull String password, @NotNull String realName, String email) {
-    if (users.containsKey(userName)) {
+  public User add(@NotNull String username, @NotNull String password, @NotNull String realName, String email) {
+    if (users.containsKey(username)) {
       return null;
     }
 
-    final UserWithPassword userWithPassword = new UserWithPassword(User.create(userName, realName, email, userName, UserType.Local), password);
-    users.put(userWithPassword.getUser().getUserName(), userWithPassword);
+    final UserWithPassword userWithPassword = new UserWithPassword(User.create(username, realName, email, username, UserType.Local), password);
+    users.put(userWithPassword.getUser().getUsername(), userWithPassword);
     return userWithPassword.getUser();
   }
 
@@ -49,8 +49,8 @@ public final class LocalUserDB implements UserDB {
   }
 
   @Override
-  public User check(@NotNull String userName, @NotNull String password) {
-    final UserWithPassword userWithPassword = users.get(userName);
+  public User check(@NotNull String username, @NotNull String password) {
+    final UserWithPassword userWithPassword = users.get(username);
     if (userWithPassword == null)
       return null;
 
@@ -62,8 +62,8 @@ public final class LocalUserDB implements UserDB {
 
   @Nullable
   @Override
-  public User lookupByUserName(@NotNull String userName) {
-    final UserWithPassword user = users.get(userName);
+  public User lookupByUserName(@NotNull String username) {
+    final UserWithPassword user = users.get(username);
     return user == null ? null : user.getUser();
   }
 

--- a/src/main/java/svnserver/auth/LocalUserDB.java
+++ b/src/main/java/svnserver/auth/LocalUserDB.java
@@ -37,7 +37,8 @@ public final class LocalUserDB implements UserDB {
       return null;
     }
 
-    final UserWithPassword userWithPassword = new UserWithPassword(User.create(username, realName, email, username, UserType.Local), password);
+    final User user = User.create(username, realName, email, username, UserType.Local, null);
+    final UserWithPassword userWithPassword = new UserWithPassword(user, password);
     users.put(userWithPassword.getUser().getUsername(), userWithPassword);
     return userWithPassword.getUser();
   }

--- a/src/main/java/svnserver/auth/User.java
+++ b/src/main/java/svnserver/auth/User.java
@@ -25,7 +25,7 @@ public final class User {
 
   private final boolean isAnonymous;
   @NotNull
-  private final String userName;
+  private final String username;
   @NotNull
   private final String realName;
   @Nullable
@@ -35,8 +35,8 @@ public final class User {
   @NotNull
   private final UserType type;
 
-  protected User(@NotNull String userName, @NotNull String realName, @Nullable String email, @Nullable String externalId, boolean isAnonymous, @NotNull UserType type) {
-    this.userName = userName;
+  protected User(@NotNull String username, @NotNull String realName, @Nullable String email, @Nullable String externalId, boolean isAnonymous, @NotNull UserType type) {
+    this.username = username;
     this.realName = realName;
     this.email = email;
     this.externalId = externalId;
@@ -45,8 +45,8 @@ public final class User {
   }
 
   @NotNull
-  public static User create(@NotNull String userName, @NotNull String realName, @Nullable String email, @Nullable String externalId, @NotNull UserType type) {
-    return new User(userName, realName, email, externalId, false, type);
+  public static User create(@NotNull String username, @NotNull String realName, @Nullable String email, @Nullable String externalId, @NotNull UserType type) {
+    return new User(username, realName, email, externalId, false, type);
   }
 
   public static User getAnonymous() {
@@ -77,7 +77,7 @@ public final class User {
       env.put("GAS_EMAIL", getEmail());
     }
     env.put("GAS_NAME", getRealName());
-    env.put("GAS_LOGIN", getUserName());
+    env.put("GAS_LOGIN", getUsername());
   }
 
   @Nullable
@@ -91,13 +91,13 @@ public final class User {
   }
 
   @NotNull
-  public String getUserName() {
-    return userName;
+  public String getUsername() {
+    return username;
   }
 
   @Override
   public int hashCode() {
-    int result = userName.hashCode();
+    int result = username.hashCode();
     result = 31 * result + realName.hashCode();
     result = 31 * result + type.hashCode();
     result = 31 * result + (email != null ? email.hashCode() : 0);
@@ -113,7 +113,7 @@ public final class User {
 
     return Objects.equals(externalId, user.externalId)
         && Objects.equals(email, user.email)
-        && userName.equals(user.userName)
+        && username.equals(user.username)
         && realName.equals(user.realName)
         && type.equals(user.type)
         && (isAnonymous == user.isAnonymous);
@@ -121,6 +121,6 @@ public final class User {
 
   @Override
   public String toString() {
-    return userName;
+    return username;
   }
 }

--- a/src/main/java/svnserver/auth/User.java
+++ b/src/main/java/svnserver/auth/User.java
@@ -21,7 +21,7 @@ import java.util.Objects;
  */
 public final class User {
   @NotNull
-  private static final User anonymousUser = new User("$anonymous", "anonymous", null, null, true, UserType.Local);
+  private static final User anonymousUser = new User("$anonymous", "anonymous", null, null, true, UserType.Local, null);
 
   private final boolean isAnonymous;
   @NotNull
@@ -34,23 +34,31 @@ public final class User {
   private final String externalId;
   @NotNull
   private final UserType type;
+  @Nullable
+  private final LfsCredentials lfsCredentials;
 
-  protected User(@NotNull String username, @NotNull String realName, @Nullable String email, @Nullable String externalId, boolean isAnonymous, @NotNull UserType type) {
+  protected User(@NotNull String username, @NotNull String realName, @Nullable String email, @Nullable String externalId, boolean isAnonymous, @NotNull UserType type, @Nullable LfsCredentials lfsCredentials) {
     this.username = username;
     this.realName = realName;
     this.email = email;
     this.externalId = externalId;
     this.isAnonymous = isAnonymous;
     this.type = type;
+    this.lfsCredentials = lfsCredentials;
   }
 
   @NotNull
-  public static User create(@NotNull String username, @NotNull String realName, @Nullable String email, @Nullable String externalId, @NotNull UserType type) {
-    return new User(username, realName, email, externalId, false, type);
+  public static User create(@NotNull String username, @NotNull String realName, @Nullable String email, @Nullable String externalId, @NotNull UserType type, @Nullable LfsCredentials lfsCredentials) {
+    return new User(username, realName, email, externalId, false, type, lfsCredentials);
   }
 
   public static User getAnonymous() {
     return anonymousUser;
+  }
+
+  @Nullable
+  public LfsCredentials getLfsCredentials() {
+    return lfsCredentials;
   }
 
   @Nullable
@@ -122,5 +130,17 @@ public final class User {
   @Override
   public String toString() {
     return username;
+  }
+
+  public static class LfsCredentials {
+    @NotNull
+    public final String username;
+    @NotNull
+    public final String password;
+
+    public LfsCredentials(@NotNull String username, @NotNull String password) {
+      this.username = username;
+      this.password = password;
+    }
   }
 }

--- a/src/main/java/svnserver/auth/UserDB.java
+++ b/src/main/java/svnserver/auth/UserDB.java
@@ -25,10 +25,10 @@ public interface UserDB extends Shared {
   @NotNull
   Collection<Authenticator> authenticators();
 
-  User check(@NotNull String userName, @NotNull String password) throws SVNException;
+  User check(@NotNull String username, @NotNull String password) throws SVNException;
 
   @Nullable
-  User lookupByUserName(@NotNull String userName) throws SVNException;
+  User lookupByUserName(@NotNull String username) throws SVNException;
 
   @Nullable
   User lookupByExternal(@NotNull String external) throws SVNException;

--- a/src/main/java/svnserver/auth/cache/CacheUserDB.java
+++ b/src/main/java/svnserver/auth/cache/CacheUserDB.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ExecutionException;
  */
 public final class CacheUserDB implements UserDB {
   @NotNull
-  private final static User invalidUser = User.create("invalid", "invalid", null, null, UserType.Local);
+  private final static User invalidUser = User.create("invalid", "invalid", null, null, UserType.Local, null);
   @NotNull
   private final Collection<Authenticator> authenticators = Collections.singleton(new PlainAuthenticator(this));
   @NotNull

--- a/src/main/java/svnserver/auth/cache/CacheUserDB.java
+++ b/src/main/java/svnserver/auth/cache/CacheUserDB.java
@@ -53,14 +53,14 @@ public final class CacheUserDB implements UserDB {
   }
 
   @Override
-  public User check(@NotNull String userName, @NotNull String password) throws SVNException {
-    return cached("c." + hash(userName, password), db -> db.check(userName, password));
+  public User check(@NotNull String username, @NotNull String password) throws SVNException {
+    return cached("c." + hash(username, password), db -> db.check(username, password));
   }
 
   @Nullable
   @Override
-  public User lookupByUserName(@NotNull String userName) throws SVNException {
-    return cached("l." + userName, db -> db.lookupByUserName(userName));
+  public User lookupByUserName(@NotNull String username) throws SVNException {
+    return cached("l." + username, db -> db.lookupByUserName(username));
   }
 
   @Nullable
@@ -91,9 +91,9 @@ public final class CacheUserDB implements UserDB {
   }
 
   @NotNull
-  private String hash(@NotNull String userName, @NotNull String password) {
+  private String hash(@NotNull String username, @NotNull String password) {
     final MessageDigest digest = HashHelper.sha256();
-    hashPacket(digest, userName.getBytes(StandardCharsets.UTF_8));
+    hashPacket(digest, username.getBytes(StandardCharsets.UTF_8));
     hashPacket(digest, password.getBytes(StandardCharsets.UTF_8));
     return Hex.encodeHexString(digest.digest());
   }

--- a/src/main/java/svnserver/auth/combine/CombineUserDB.java
+++ b/src/main/java/svnserver/auth/combine/CombineUserDB.java
@@ -41,14 +41,14 @@ public final class CombineUserDB implements UserDB {
   }
 
   @Override
-  public User check(@NotNull String userName, @NotNull String password) throws SVNException {
-    return firstAvailable(userDB -> userDB.check(userName, password));
+  public User check(@NotNull String username, @NotNull String password) throws SVNException {
+    return firstAvailable(userDB -> userDB.check(username, password));
   }
 
   @Nullable
   @Override
-  public User lookupByUserName(@NotNull String userName) throws SVNException {
-    return firstAvailable(userDB -> userDB.lookupByUserName(userName));
+  public User lookupByUserName(@NotNull String username) throws SVNException {
+    return firstAvailable(userDB -> userDB.lookupByUserName(username));
   }
 
   @Nullable

--- a/src/main/java/svnserver/auth/ldap/LdapUserDB.java
+++ b/src/main/java/svnserver/auth/ldap/LdapUserDB.java
@@ -233,7 +233,7 @@ public final class LdapUserDB implements UserDB {
       email = login + fakeMailSuffix;
 
     log.debug("LDAP authentication successful for user: {}", username);
-    return User.create(login, realName != null ? realName : login, email, null, UserType.LDAP);
+    return User.create(login, realName != null ? realName : login, email, null, UserType.LDAP, null);
   }
 
   @Nullable

--- a/src/main/java/svnserver/auth/ldap/config/LdapUserDBConfig.java
+++ b/src/main/java/svnserver/auth/ldap/config/LdapUserDBConfig.java
@@ -160,8 +160,8 @@ public final class LdapUserDBConfig implements UserDBConfig {
   }
 
   @NotNull
-  public Filter createSearchFilter(@NotNull String userName) throws LDAPException {
-    final Filter filter = Filter.createEqualityFilter(loginAttribute, userName);
+  public Filter createSearchFilter(@NotNull String username) throws LDAPException {
+    final Filter filter = Filter.createEqualityFilter(loginAttribute, username);
     return searchFilter.isEmpty()
         ? filter
         : Filter.createANDFilter(Filter.create(searchFilter), filter);

--- a/src/main/java/svnserver/ext/gitea/auth/GiteaUserDB.java
+++ b/src/main/java/svnserver/ext/gitea/auth/GiteaUserDB.java
@@ -58,16 +58,16 @@ public final class GiteaUserDB implements UserDB {
   }
 
   @Override
-  public User check(@NotNull String userName, @NotNull String password) {
+  public User check(@NotNull String username, @NotNull String password) {
     try {
-      final ApiClient apiClient = context.connect(userName, password);
+      final ApiClient apiClient = context.connect(username, password);
       final UserApi userApi = new UserApi(apiClient);
       return createUser(userApi.userGetCurrent());
     } catch (ApiException e) {
       if (e.getCode() == HttpURLConnection.HTTP_UNAUTHORIZED || e.getCode() == HttpURLConnection.HTTP_FORBIDDEN) {
         return null;
       }
-      log.warn("User password check error: " + userName, e);
+      log.warn("User password check error: " + username, e);
       return null;
     }
   }
@@ -79,15 +79,15 @@ public final class GiteaUserDB implements UserDB {
 
   @Nullable
   @Override
-  public User lookupByUserName(@NotNull String userName) {
+  public User lookupByUserName(@NotNull String username) {
     ApiClient apiClient = context.connect();
     try {
       UserApi userApi = new UserApi(apiClient);
-      io.gitea.model.User user = userApi.userGet(userName);
+      io.gitea.model.User user = userApi.userGet(username);
       return createUser(user);
     } catch (ApiException e) {
       if (e.getCode() != HttpURLConnection.HTTP_NOT_FOUND) {
-        log.warn("User lookup by name error: " + userName, e);
+        log.warn("User lookup by name error: " + username, e);
       }
       return null;
     }

--- a/src/main/java/svnserver/ext/gitea/mapping/GiteaAccess.java
+++ b/src/main/java/svnserver/ext/gitea/mapping/GiteaAccess.java
@@ -54,8 +54,8 @@ final class GiteaAccess implements VcsAccess {
     this.cache = CacheBuilder.newBuilder().maximumSize(config.getCacheMaximumSize())
         .expireAfterWrite(config.getCacheTimeSec(), TimeUnit.SECONDS).build(new CacheLoader<String, Repository>() {
           @Override
-          public Repository load(@NotNull String userName) throws Exception {
-            if (userName.isEmpty()) {
+          public Repository load(@NotNull String username) throws Exception {
+            if (username.isEmpty()) {
               try {
                 final ApiClient apiClient = context.connect();
                 final RepositoryApi repositoryApi = new RepositoryApi(apiClient);
@@ -77,7 +77,7 @@ final class GiteaAccess implements VcsAccess {
             }
             // Sudo as the user
             try {
-              final ApiClient apiClient = context.connect(userName);
+              final ApiClient apiClient = context.connect(username);
               final RepositoryApi repositoryApi = new RepositoryApi(apiClient);
 
               return repositoryApi.repoGetByID(projectId);
@@ -131,7 +131,7 @@ final class GiteaAccess implements VcsAccess {
       if (user.isAnonymous())
         return cache.get("");
 
-      final String key = user.getUserName();
+      final String key = user.getUsername();
       if (key.isEmpty()) {
         throw new IllegalStateException("Found user without identifier: " + user);
       }

--- a/src/main/java/svnserver/ext/gitlab/auth/GitLabUserDB.java
+++ b/src/main/java/svnserver/ext/gitlab/auth/GitLabUserDB.java
@@ -58,18 +58,18 @@ public final class GitLabUserDB implements UserDB {
   }
 
   @Override
-  public User check(@NotNull String userName, @NotNull String password) {
+  public User check(@NotNull String username, @NotNull String password) {
     try {
-      final GitlabSession session = context.connect(userName, password);
+      final GitlabSession session = context.connect(username, password);
       return createUser(session);
     } catch (GitlabAPIException e) {
       if (e.getResponseCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
         return null;
       }
-      log.warn("User password check error: " + userName, e);
+      log.warn("User password check error: " + username, e);
       return null;
     } catch (IOException e) {
-      log.warn("User password check error: " + userName, e);
+      log.warn("User password check error: " + username, e);
       return null;
     }
   }
@@ -81,13 +81,13 @@ public final class GitLabUserDB implements UserDB {
 
   @Nullable
   @Override
-  public User lookupByUserName(@NotNull String userName) {
+  public User lookupByUserName(@NotNull String username) {
     try {
-      return createUser(context.connect().getUserViaSudo(userName));
+      return createUser(context.connect().getUserViaSudo(username));
     } catch (FileNotFoundException e) {
       return null;
     } catch (IOException e) {
-      log.warn("User lookup by name error: " + userName, e);
+      log.warn("User lookup by name error: " + username, e);
       return null;
     }
   }

--- a/src/main/java/svnserver/ext/gitlab/config/GitLabContext.java
+++ b/src/main/java/svnserver/ext/gitlab/config/GitLabContext.java
@@ -24,6 +24,8 @@ import svnserver.context.SharedContext;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * GitLab context.
@@ -55,7 +57,7 @@ public final class GitLabContext implements Shared {
   @NotNull
   public static GitLabToken obtainAccessToken(@NotNull String gitlabUrl, @NotNull String username, @NotNull String password, boolean sudoScope) throws IOException {
     try {
-      final OAuthGetAccessToken tokenServerUrl = new OAuthGetAccessToken(gitlabUrl + "/oauth/token" + (sudoScope ? "?scope=api%20sudo" : ""));
+      final OAuthGetAccessToken tokenServerUrl = new OAuthGetAccessToken(gitlabUrl + "/oauth/token?scope=api" + (sudoScope ? "%20sudo" : ""));
       final TokenResponse oauthResponse = new PasswordTokenRequest(transport, JacksonFactory.getDefaultInstance(), tokenServerUrl, username, password).execute();
       return new GitLabToken(TokenType.ACCESS_TOKEN, oauthResponse.getAccessToken());
     } catch (TokenResponseException e) {

--- a/src/main/java/svnserver/ext/gitlab/mapping/GitLabAccess.java
+++ b/src/main/java/svnserver/ext/gitlab/mapping/GitLabAccess.java
@@ -107,7 +107,7 @@ final class GitLabAccess implements VcsAccess {
       return false;
     }
     return owner.getId().toString().equals(user.getExternalId())
-        || owner.getName().equals(user.getUserName());
+        || owner.getName().equals(user.getUsername());
   }
 
   private boolean hasAccess(@Nullable GitlabProjectAccessLevel access, @NotNull GitlabAccessLevel level) {
@@ -122,7 +122,7 @@ final class GitLabAccess implements VcsAccess {
       if (user.isAnonymous())
         return cache.get("");
 
-      final String key = user.getExternalId() != null ? user.getExternalId() : user.getUserName();
+      final String key = user.getExternalId() != null ? user.getExternalId() : user.getUsername();
       if (key.isEmpty()) {
         throw new IllegalStateException("Found user without identificator: " + user);
       }

--- a/src/main/java/svnserver/ext/gitlfs/storage/BasicAuthHttpLfsStorage.java
+++ b/src/main/java/svnserver/ext/gitlfs/storage/BasicAuthHttpLfsStorage.java
@@ -7,9 +7,11 @@
  */
 package svnserver.ext.gitlfs.storage;
 
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.eclipse.jgit.lib.Constants;
 import org.jetbrains.annotations.NotNull;
 import ru.bozaro.gitlfs.client.Client;
+import ru.bozaro.gitlfs.client.auth.AuthProvider;
 import ru.bozaro.gitlfs.client.auth.BasicAuthProvider;
 import svnserver.auth.User;
 import svnserver.ext.gitlfs.server.LfsServer;
@@ -24,19 +26,32 @@ import java.net.URI;
  */
 public class BasicAuthHttpLfsStorage extends LfsHttpStorage {
   @NotNull
-  private final Client client;
+  private final CloseableHttpClient httpClient = createHttpClient();
+  @NotNull
+  private final URI baseURI;
+  @NotNull
+  private final BasicAuthProvider fallbackAuthProvider;
 
   public BasicAuthHttpLfsStorage(@NotNull String baseUrl, @NotNull String repositoryName, @NotNull String username, @NotNull String password) {
+    baseURI = buildAuthURI(baseUrl, repositoryName);
+    fallbackAuthProvider = new BasicAuthProvider(baseURI, username, password);
+  }
+
+  @NotNull
+  protected static URI buildAuthURI(@NotNull String baseUrl, @NotNull String repositoryName) {
     if (!baseUrl.endsWith("/"))
       baseUrl += "/";
 
-    final URI href = URI.create(baseUrl + repositoryName + Constants.DOT_GIT_EXT + "/" + LfsServer.SERVLET_BASE);
-    final BasicAuthProvider authProvider = new BasicAuthProvider(href, username, password);
-    client = new Client(authProvider, createHttpClient());
+    return URI.create(baseUrl + repositoryName + Constants.DOT_GIT_EXT + "/" + LfsServer.SERVLET_BASE);
   }
 
   @NotNull
   protected final Client lfsClient(@NotNull User user) {
-    return client;
+    return new Client(authProvider(user, baseURI), httpClient);
+  }
+
+  @NotNull
+  protected AuthProvider authProvider(@NotNull User user, @NotNull URI baseURI) {
+    return fallbackAuthProvider;
   }
 }

--- a/src/main/java/svnserver/ext/gitlfs/storage/BasicAuthHttpLfsStorage.java
+++ b/src/main/java/svnserver/ext/gitlfs/storage/BasicAuthHttpLfsStorage.java
@@ -35,9 +35,6 @@ public class BasicAuthHttpLfsStorage extends LfsHttpStorage {
     client = new Client(authProvider, createHttpClient());
   }
 
-  public final void invalidate(@NotNull User user) {
-  }
-
   @NotNull
   protected final Client lfsClient(@NotNull User user) {
     return client;

--- a/src/main/java/svnserver/ext/gitlfs/storage/local/LfsLocalWriter.java
+++ b/src/main/java/svnserver/ext/gitlfs/storage/local/LfsLocalWriter.java
@@ -163,7 +163,7 @@ public final class LfsLocalWriter extends LfsWriter {
               if (user.getEmail() != null) {
                 map.put(LfsLocalStorage.META_EMAIL, user.getEmail());
               }
-              map.put(LfsLocalStorage.META_USER_NAME, user.getUserName());
+              map.put(LfsLocalStorage.META_USER_NAME, user.getUsername());
               map.put(LfsLocalStorage.META_REAL_NAME, user.getRealName());
             }
             stream.write(Pointer.serializePointer(map));

--- a/src/main/java/svnserver/ext/gitlfs/storage/network/LfsHttpStorage.java
+++ b/src/main/java/svnserver/ext/gitlfs/storage/network/LfsHttpStorage.java
@@ -44,6 +44,7 @@ import static svnserver.repository.locks.LockDesc.toLfsPath;
  * HTTP remote storage for LFS files.
  *
  * @author Artem V. Navrotskiy <bozaro@users.noreply.github.com>
+ * @author Marat Radchenko <marat@slonopotamus.org>
  */
 public abstract class LfsHttpStorage implements LfsStorage {
 
@@ -62,8 +63,6 @@ public abstract class LfsHttpStorage implements LfsStorage {
         .build();
   }
 
-  public abstract void invalidate(@NotNull User user);
-
   @Override
   @Nullable
   public LfsReader getReader(@NotNull String oid, long size) throws IOException {
@@ -81,7 +80,7 @@ public abstract class LfsHttpStorage implements LfsStorage {
       if (item.getError() != null)
         return null;
 
-      return new LfsHttpReader(this, item, item);
+      return new LfsHttpReader(lfsClient, item);
     } catch (RequestException e) {
       log.error("HTTP request error:" + e.getMessage(), e);
       throw e;
@@ -94,7 +93,8 @@ public abstract class LfsHttpStorage implements LfsStorage {
   @NotNull
   @Override
   public final LfsWriter getWriter(@NotNull User user) {
-    return new LfsHttpWriter(this, user);
+    final Client lfsClient = lfsClient(user);
+    return new LfsHttpWriter(lfsClient);
   }
 
   @NotNull

--- a/src/main/java/svnserver/ext/gitlfs/storage/network/LfsHttpWriter.java
+++ b/src/main/java/svnserver/ext/gitlfs/storage/network/LfsHttpWriter.java
@@ -14,7 +14,6 @@ import ru.bozaro.gitlfs.client.Client;
 import ru.bozaro.gitlfs.common.data.*;
 import svnserver.HashHelper;
 import svnserver.TemporaryOutputStream;
-import svnserver.auth.User;
 import svnserver.ext.gitlfs.storage.LfsWriter;
 import svnserver.ext.gitlfs.storage.local.LfsLocalStorage;
 
@@ -29,17 +28,14 @@ import java.util.Collections;
  */
 public final class LfsHttpWriter extends LfsWriter {
   @NotNull
-  private final LfsHttpStorage owner;
-  @NotNull
-  private final User user;
+  private final Client lfsClient;
   @NotNull
   private final TemporaryOutputStream content;
   @NotNull
   private final MessageDigest digestSha;
 
-  LfsHttpWriter(@NotNull LfsHttpStorage owner, @NotNull User user) {
-    this.owner = owner;
-    this.user = user;
+  LfsHttpWriter(@NotNull Client lfsClient) {
+    this.lfsClient = lfsClient;
     this.digestSha = HashHelper.sha256();
     this.content = new TemporaryOutputStream();
   }
@@ -64,8 +60,6 @@ public final class LfsHttpWriter extends LfsWriter {
     if (expectedOid != null && !expectedOid.equals(oid)) {
       throw new IOException("Invalid stream checksum: expected " + expectedOid + ", but actual " + LfsLocalStorage.OID_PREFIX + sha);
     }
-
-    final Client lfsClient = owner.lfsClient(user);
 
     final BatchRes batchRes = lfsClient.postBatch(new BatchReq(Operation.Upload, Collections.singletonList(new Meta(sha, content.size()))));
     if (batchRes.getObjects().isEmpty())

--- a/src/main/java/svnserver/ext/keys/KeyUserDB.java
+++ b/src/main/java/svnserver/ext/keys/KeyUserDB.java
@@ -43,13 +43,13 @@ public final class KeyUserDB implements UserDB {
     }
 
     @Override
-    public User check(@NotNull String userName, @NotNull String password) throws SVNException {
-        return internal.check(userName, password);
+    public User check(@NotNull String username, @NotNull String password) throws SVNException {
+        return internal.check(username, password);
     }
 
     @Override
-	public @Nullable User lookupByUserName(@NotNull String userName) throws SVNException {
-		return internal.lookupByUserName(userName);
+	public @Nullable User lookupByUserName(@NotNull String username) throws SVNException {
+		return internal.lookupByUserName(username);
 	}
 
 	@Override

--- a/src/main/java/svnserver/ext/web/server/WebServer.java
+++ b/src/main/java/svnserver/ext/web/server/WebServer.java
@@ -85,8 +85,8 @@ public final class WebServer implements Shared {
     final RequestLogHandler logHandler = new RequestLogHandler();
     logHandler.setRequestLog((request, response) -> {
       final User user = (User) request.getAttribute(User.class.getName());
-      final String userName = (user == null || user.isAnonymous()) ? "" : user.getUserName();
-      log.info("{}:{} - {} - \"{} {}\" {} {}", request.getRemoteHost(), request.getRemotePort(), userName, request.getMethod(), request.getHttpURI(), response.getStatus(), response.getReason());
+      final String username = (user == null || user.isAnonymous()) ? "" : user.getUsername();
+      log.info("{}:{} - {} - \"{} {}\" {} {}", request.getRemoteHost(), request.getRemotePort(), username, request.getMethod(), request.getHttpURI(), response.getStatus(), response.getReason());
     });
 
     final HandlerCollection handlers = new HandlerCollection();

--- a/src/main/java/svnserver/ext/web/token/TokenHelper.java
+++ b/src/main/java/svnserver/ext/web/token/TokenHelper.java
@@ -90,7 +90,8 @@ public final class TokenHelper {
           claims.getClaimValue("name", String.class),
           claims.getClaimValue("email", String.class),
           claims.getClaimValue("external", String.class),
-          UserType.valueOf(claims.getClaimValue("type", String.class))
+          UserType.valueOf(claims.getClaimValue("type", String.class)),
+          null
       );
     } catch (JoseException | MalformedClaimException | InvalidJwtException e) {
       log.warn("Token parsing error: " + e.getMessage());

--- a/src/main/java/svnserver/ext/web/token/TokenHelper.java
+++ b/src/main/java/svnserver/ext/web/token/TokenHelper.java
@@ -47,7 +47,7 @@ public final class TokenHelper {
       claims.setIssuedAtToNow();  // when the token was issued/created (now)
       claims.setNotBeforeMinutesInThePast(0.5f); // time before which the token is not yet valid (30 seconds ago)
       if (!user.isAnonymous()) {
-        claims.setSubject(user.getUserName()); // the subject/principal is whom the token is about
+        claims.setSubject(user.getUsername()); // the subject/principal is whom the token is about
         setClaim(claims, "email", user.getEmail());
         setClaim(claims, "name", user.getRealName());
         setClaim(claims, "external", user.getExternalId());

--- a/src/main/java/svnserver/repository/locks/LocalLockManager.java
+++ b/src/main/java/svnserver/repository/locks/LocalLockManager.java
@@ -74,7 +74,7 @@ public class LocalLockManager implements LockStorage {
       if (!lockId.equals(lock.getValue().getToken()))
         continue;
 
-      if (!breakLock && !user.getUserName().equals(lock.getValue().getOwner()))
+      if (!breakLock && !user.getUsername().equals(lock.getValue().getOwner()))
         throw new LockConflictException(LockDesc.toLock(lock.getValue()));
 
       result = lock.getValue();
@@ -114,7 +114,7 @@ public class LocalLockManager implements LockStorage {
     final List<Lock> ourLocks = new ArrayList<>();
     final List<Lock> theirLocks = new ArrayList<>();
     for (LockDesc lock : getLocks(user, branch, null, (String) null))
-      (user.getUserName().equals(lock.getOwner()) ? ourLocks : theirLocks).add(LockDesc.toLock(lock));
+      (user.getUsername().equals(lock.getOwner()) ? ourLocks : theirLocks).add(LockDesc.toLock(lock));
 
     return new VerifyLocksResult(ourLocks, theirLocks);
   }
@@ -131,7 +131,7 @@ public class LocalLockManager implements LockStorage {
       if (lock == null)
         throw new SVNException(SVNErrorMessage.create(SVNErrorCode.FS_NO_SUCH_LOCK, path));
 
-      if (!breakLock && (!lock.getToken().equals(token) || !user.getUserName().equals(lock.getOwner())))
+      if (!breakLock && (!lock.getToken().equals(token) || !user.getUsername().equals(lock.getOwner())))
         throw new LockConflictException(LockDesc.toLock(lock));
     }
 
@@ -236,7 +236,7 @@ public class LocalLockManager implements LockStorage {
     if (!stealLock && currentLock != null)
       throw new LockConflictException(LockDesc.toLock(currentLock));
 
-    return new LockDesc(path, branch, hash, createLockId(), user.getUserName(), comment, System.currentTimeMillis());
+    return new LockDesc(path, branch, hash, createLockId(), user.getUsername(), comment, System.currentTimeMillis());
   }
 
   @NotNull

--- a/src/test/java/svnserver/SvnTestServer.java
+++ b/src/test/java/svnserver/SvnTestServer.java
@@ -189,14 +189,14 @@ public final class SvnTestServer implements SvnTester {
   }
 
   @NotNull
-  public SVNRepository openSvnRepository(@NotNull String userName, @NotNull String password) throws SVNException {
-    return openSvnRepository(getUrl(), userName, password);
+  public SVNRepository openSvnRepository(@NotNull String username, @NotNull String password) throws SVNException {
+    return openSvnRepository(getUrl(), username, password);
   }
 
   @NotNull
-  public static SVNRepository openSvnRepository(@NotNull SVNURL url, @NotNull String userName, @NotNull String password) throws SVNException {
+  public static SVNRepository openSvnRepository(@NotNull SVNURL url, @NotNull String username, @NotNull String password) throws SVNException {
     final SVNRepository repo = SVNRepositoryFactory.create(url);
-    repo.setAuthenticationManager(BasicAuthenticationManager.newInstance(userName, password.toCharArray()));
+    repo.setAuthenticationManager(BasicAuthenticationManager.newInstance(username, password.toCharArray()));
     return repo;
   }
 
@@ -258,13 +258,13 @@ public final class SvnTestServer implements SvnTester {
   }
 
   @NotNull
-  private SvnOperationFactory createOperationFactory(@NotNull String userName, @NotNull String password) {
+  private SvnOperationFactory createOperationFactory(@NotNull String username, @NotNull String password) {
     final SVNWCContext wcContext = new SVNWCContext(new DefaultSVNOptions(getTempDirectory().toFile(), true), null);
     wcContext.setSqliteTemporaryDbInMemory(true);
     wcContext.setSqliteJournalMode(SqlJetPagerJournalMode.MEMORY);
 
     final SvnOperationFactory factory = new SvnOperationFactory(wcContext);
-    factory.setAuthenticationManager(BasicAuthenticationManager.newInstance(userName, password.toCharArray()));
+    factory.setAuthenticationManager(BasicAuthenticationManager.newInstance(username, password.toCharArray()));
     svnFactories.add(factory);
     return factory;
   }

--- a/src/test/java/svnserver/auth/ACLTest.java
+++ b/src/test/java/svnserver/auth/ACLTest.java
@@ -23,10 +23,10 @@ import java.util.Map;
 public final class ACLTest {
 
   @NotNull
-  private static final User Bob = User.create("bob", "Bob", "bob@acme.com", null, UserType.Local);
+  private static final User Bob = User.create("bob", "Bob", "bob@acme.com", null, UserType.Local, null);
 
   @NotNull
-  private static final User Alice = User.create("alice", "Alice", "alice@acme.com", null, UserType.Local);
+  private static final User Alice = User.create("alice", "Alice", "alice@acme.com", null, UserType.Local, null);
 
   @Test
   public void emptyDeny() {
@@ -146,7 +146,7 @@ public final class ACLTest {
 
     Assert.assertFalse(acl.canRead(Bob, Constants.MASTER, "/"));
     Assert.assertFalse(acl.canRead(User.getAnonymous(), Constants.MASTER, "/"));
-    Assert.assertTrue(acl.canRead(User.create("bla", "bla", "bla", "bla", UserType.GitLab), Constants.MASTER, "/"));
+    Assert.assertTrue(acl.canRead(User.create("bla", "bla", "bla", "bla", UserType.GitLab, null), Constants.MASTER, "/"));
   }
 
   @Test

--- a/src/test/java/svnserver/auth/ACLTest.java
+++ b/src/test/java/svnserver/auth/ACLTest.java
@@ -40,7 +40,7 @@ public final class ACLTest {
   public void groupOfGroup() {
     final Map<String, String[]> groups = ImmutableMap.<String, String[]>builder()
         .put("groupOfGroup", new String[]{"@group"})
-        .put("group", new String[]{Bob.getUserName()})
+        .put("group", new String[]{Bob.getUsername()})
         .build();
     final ACL acl = new ACL(groups, Collections.singletonMap("/", Collections.singletonMap("@groupOfGroup", "r")));
 
@@ -53,7 +53,7 @@ public final class ACLTest {
     final Map<String, String[]> groups = ImmutableMap.<String, String[]>builder()
         .put("groupOfGroupOfGroup", new String[]{"@groupOfGroup"})
         .put("groupOfGroup", new String[]{"@group"})
-        .put("group", new String[]{Bob.getUserName()})
+        .put("group", new String[]{Bob.getUsername()})
         .build();
     final ACL acl = new ACL(groups, Collections.singletonMap("/", Collections.singletonMap("@groupOfGroupOfGroup", "r")));
 
@@ -92,7 +92,7 @@ public final class ACLTest {
 
   @Test
   public void branchAllow() {
-    final ACL acl = new ACL(Collections.emptyMap(), Collections.singletonMap("master:/", Collections.singletonMap(Bob.getUserName(), "rw")));
+    final ACL acl = new ACL(Collections.emptyMap(), Collections.singletonMap("master:/", Collections.singletonMap(Bob.getUsername(), "rw")));
     Assert.assertTrue(acl.canRead(Bob, "master", "/"));
     Assert.assertFalse(acl.canRead(Bob, "release", "/"));
   }
@@ -100,8 +100,8 @@ public final class ACLTest {
   @Test
   public void branchDeny() {
     final Map<String, Map<String, String>> entries = ImmutableMap.<String, Map<String, String>>builder()
-        .put("master:/", Collections.singletonMap(Bob.getUserName(), null))
-        .put("/", Collections.singletonMap(Bob.getUserName(), "rw"))
+        .put("master:/", Collections.singletonMap(Bob.getUsername(), null))
+        .put("/", Collections.singletonMap(Bob.getUsername(), "rw"))
         .build();
     final ACL acl = new ACL(Collections.emptyMap(), entries);
     Assert.assertFalse(acl.canRead(Bob, "master", "/"));
@@ -159,7 +159,7 @@ public final class ACLTest {
 
   @Test
   public void rootAllow() {
-    final ACL acl = new ACL(Collections.emptyMap(), Collections.singletonMap("/", Collections.singletonMap(Bob.getUserName(), "rw")));
+    final ACL acl = new ACL(Collections.emptyMap(), Collections.singletonMap("/", Collections.singletonMap(Bob.getUsername(), "rw")));
 
     Assert.assertTrue(acl.canRead(Bob, Constants.MASTER, "/"));
     Assert.assertFalse(acl.canRead(Alice, Constants.MASTER, "/"));
@@ -176,7 +176,7 @@ public final class ACLTest {
 
   @Test
   public void deepAllow() {
-    final ACL acl = new ACL(Collections.emptyMap(), Collections.singletonMap("/qwe", Collections.singletonMap(Bob.getUserName(), "rw")));
+    final ACL acl = new ACL(Collections.emptyMap(), Collections.singletonMap("/qwe", Collections.singletonMap(Bob.getUsername(), "rw")));
 
     Assert.assertFalse(acl.canRead(Bob, Constants.MASTER, "/"));
     Assert.assertFalse(acl.canRead(Alice, Constants.MASTER, "/"));
@@ -194,8 +194,8 @@ public final class ACLTest {
   @Test
   public void deepDeny() {
     final Map<String, Map<String, String>> entries = ImmutableMap.<String, Map<String, String>>builder()
-        .put("/qwe", Collections.singletonMap(Bob.getUserName(), null))
-        .put("/", Collections.singletonMap(Bob.getUserName(), "rw"))
+        .put("/qwe", Collections.singletonMap(Bob.getUsername(), null))
+        .put("/", Collections.singletonMap(Bob.getUsername(), "rw"))
         .build();
 
     final ACL acl = new ACL(Collections.emptyMap(), entries);
@@ -211,8 +211,8 @@ public final class ACLTest {
   @Test
   public void floorEntry() {
     final Map<String, Map<String, String>> entries = ImmutableMap.<String, Map<String, String>>builder()
-        .put("/", Collections.singletonMap(Bob.getUserName(), "rw"))
-        .put("/a", Collections.singletonMap(Bob.getUserName(), null))
+        .put("/", Collections.singletonMap(Bob.getUsername(), "rw"))
+        .put("/a", Collections.singletonMap(Bob.getUsername(), null))
         .build();
 
     final ACL acl = new ACL(Collections.emptyMap(), entries);

--- a/src/test/java/svnserver/auth/cache/CacheUserDBTest.java
+++ b/src/test/java/svnserver/auth/cache/CacheUserDBTest.java
@@ -22,7 +22,7 @@ import svnserver.auth.User;
 public final class CacheUserDBTest {
   @Test
   public void testSimple() throws SVNException {
-    User user = User.create("foo", "Foo", "foo@bar", "f01", UserType.Local);
+    User user = User.create("foo", "Foo", "foo@bar", "f01", UserType.Local, null);
     TestUserDB db = new TestUserDB(user);
     CacheUserDB cache = new CacheUserDB(db, CacheBuilder.newBuilder().build());
 

--- a/src/test/java/svnserver/auth/cache/TestUserDB.java
+++ b/src/test/java/svnserver/auth/cache/TestUserDB.java
@@ -34,11 +34,11 @@ final class TestUserDB implements UserDB {
   }
 
   @Override
-  public User check(@NotNull String userName, @NotNull String password) {
-    log("check: " + userName + ", " + password);
-    if (password.equals(password(userName))) {
+  public User check(@NotNull String username, @NotNull String password) {
+    log("check: " + username + ", " + password);
+    if (password.equals(password(username))) {
       for (User user : users) {
-        if (Objects.equals(user.getUserName(), userName)) {
+        if (Objects.equals(user.getUsername(), username)) {
           return user;
         }
       }
@@ -52,16 +52,16 @@ final class TestUserDB implements UserDB {
   }
 
   @NotNull
-  public String password(@NotNull String userName) {
-    return "~~~" + userName + "~~~";
+  public String password(@NotNull String username) {
+    return "~~~" + username + "~~~";
   }
 
   @Nullable
   @Override
-  public User lookupByUserName(@NotNull String userName) {
-    log("lookupByUserName: " + userName);
+  public User lookupByUserName(@NotNull String username) {
+    log("lookupByUserName: " + username);
     for (User user : users) {
-      if (Objects.equals(user.getUserName(), userName)) {
+      if (Objects.equals(user.getUsername(), username)) {
         return user;
       }
     }

--- a/src/test/java/svnserver/ext/gitea/GiteaIntegrationTest.java
+++ b/src/test/java/svnserver/ext/gitea/GiteaIntegrationTest.java
@@ -183,7 +183,7 @@ public final class GiteaIntegrationTest {
   @Test
   void testLfs() throws Exception {
     final LfsStorage storage = GiteaConfig.createLfsStorage(giteaUrl, testPublicRepository.getFullName(), administratorToken);
-    final svnserver.auth.User user = svnserver.auth.User.create(administrator, administrator, administrator, administrator, UserType.Gitea);
+    final svnserver.auth.User user = svnserver.auth.User.create(administrator, administrator, administrator, administrator, UserType.Gitea, new svnserver.auth.User.LfsCredentials(administrator, administratorPassword));
 
     LfsLocalStorageTest.checkLfs(storage, user);
     LfsLocalStorageTest.checkLfs(storage, user);

--- a/src/test/java/svnserver/ext/gitlab/GitLabIntegrationTest.java
+++ b/src/test/java/svnserver/ext/gitlab/GitLabIntegrationTest.java
@@ -189,7 +189,7 @@ public final class GitLabIntegrationTest {
   @Test
   void testLfs() throws Exception {
     final LfsStorage storage = GitLabConfig.createLfsStorage(gitlabUrl, gitlabProject.getPathWithNamespace(), root, rootPassword, null);
-    final User user = User.create(root, root, root, root, UserType.GitLab);
+    final User user = User.create(root, root, root, root, UserType.GitLab, new User.LfsCredentials(root, rootPassword));
 
     LfsLocalStorageTest.checkLfs(storage, user);
     LfsLocalStorageTest.checkLfs(storage, user);

--- a/src/test/java/svnserver/ext/gitlfs/storage/network/LfsHttpStorageTest.java
+++ b/src/test/java/svnserver/ext/gitlfs/storage/network/LfsHttpStorageTest.java
@@ -221,7 +221,7 @@ public final class LfsHttpStorageTest {
             addParameter(params, "mode", "anonymous");
           } else {
             addParameter(params, "mode", "username");
-            addParameter(params, "userId", user.getUserName());
+            addParameter(params, "userId", user.getUsername());
           }
 
           post.setEntity(new UrlEncodedFormEntity(params));

--- a/src/test/java/svnserver/ext/gitlfs/storage/network/LfsHttpStorageTest.java
+++ b/src/test/java/svnserver/ext/gitlfs/storage/network/LfsHttpStorageTest.java
@@ -207,11 +207,6 @@ public final class LfsHttpStorageTest {
     }
 
     @Override
-    public void invalidate(@NotNull User user) {
-
-    }
-
-    @Override
     protected @NotNull Client lfsClient(@NotNull User unused) {
       final CloseableHttpClient httpClient = LfsHttpStorage.createHttpClient();
 

--- a/src/test/java/svnserver/ext/web/token/TokenHelperTest.java
+++ b/src/test/java/svnserver/ext/web/token/TokenHelperTest.java
@@ -24,15 +24,20 @@ import svnserver.auth.User;
 public final class TokenHelperTest {
   @Test
   public void simpleWithoutExternal() {
-    final User expected = User.create("foo", "bar", "foo@example.com", null, UserType.Local);
+    final User expected = User.create("foo", "bar", "foo@example.com", null, UserType.Local, null);
     final String token = TokenHelper.createToken(createToken("secret"), expected, NumericDate.fromMilliseconds(System.currentTimeMillis() + 2000));
     final User actual = TokenHelper.parseToken(createToken("secret"), token, 0);
     Assert.assertEquals(actual, expected);
   }
 
+  @NotNull
+  private JsonWebEncryption createToken(@NotNull String secret) {
+    return new EncryptionFactoryAes(secret).create();
+  }
+
   @Test
   public void simpleWithExternal() {
-    final User expected = User.create("foo", "bar", "foo@example.com", "user-1", UserType.Local);
+    final User expected = User.create("foo", "bar", "foo@example.com", "user-1", UserType.Local, null);
     final String token = TokenHelper.createToken(createToken("secret"), expected, NumericDate.fromMilliseconds(System.currentTimeMillis() + 2000));
     final User actual = TokenHelper.parseToken(createToken("secret"), token, 0);
     Assert.assertEquals(actual, expected);
@@ -48,7 +53,7 @@ public final class TokenHelperTest {
 
   @Test
   public void invalidToken() {
-    final User expected = User.create("foo", "bar", "foo@example.com", null, UserType.Local);
+    final User expected = User.create("foo", "bar", "foo@example.com", null, UserType.Local, null);
     final String token = TokenHelper.createToken(createToken("big secret"), expected, NumericDate.fromMilliseconds(System.currentTimeMillis() + 2000));
     final User actual = TokenHelper.parseToken(createToken("small secret"), token, 0);
     Assert.assertNull(actual);
@@ -56,7 +61,7 @@ public final class TokenHelperTest {
 
   @Test
   public void expiredToken() {
-    final User expected = User.create("foo", "bar", "foo@example.com", null, UserType.Local);
+    final User expected = User.create("foo", "bar", "foo@example.com", null, UserType.Local, null);
     final String token = TokenHelper.createToken(createToken("secret"), expected, NumericDate.fromMilliseconds(System.currentTimeMillis() - 2000));
     final User actual = TokenHelper.parseToken(createToken("secret"), token, 0);
     Assert.assertNull(actual);
@@ -76,10 +81,5 @@ public final class TokenHelperTest {
 
     final byte[] bytesHash = TokenHelper.secretToBytes(Hex.encodeHexString(expected), 5);
     Assert.assertEquals(bytesHash.length, 5);
-  }
-
-  @NotNull
-  private JsonWebEncryption createToken(@NotNull String secret) {
-    return new EncryptionFactoryAes(secret).create();
   }
 }

--- a/src/test/java/svnserver/ldap/AuthLdapTest.java
+++ b/src/test/java/svnserver/ldap/AuthLdapTest.java
@@ -161,7 +161,7 @@ public final class AuthLdapTest {
       try {
         final User user = userDB.check(username, password);
         Assert.assertNotNull(user);
-        Assert.assertEquals(user.getUserName(), username);
+        Assert.assertEquals(user.getUsername(), username);
       } catch (SVNException e) {
         done.set(false);
       }


### PR DESCRIPTION
This PR fixes a bug that caused Git-LFS locks in GitLab to be created on behalf of administator user instead of the user who locks file through git-as-svn