### PR TITLE
Multiple fixes to locks

### DIFF
--- a/src/main/java/svnserver/repository/locks/LocalLockManager.java
+++ b/src/main/java/svnserver/repository/locks/LocalLockManager.java
@@ -186,7 +186,10 @@ public class LocalLockManager implements LockStorage {
   }
 
   @Override
-  public final void renewLocks(@NotNull GitBranch branch, @NotNull LockDesc[] lockDescs) throws IOException {
+  public final void refreshLocks(@NotNull User user, @NotNull GitBranch branch, boolean keepLocks, @NotNull LockDesc[] lockDescs) throws IOException {
+    if (!keepLocks)
+      return;
+
     final GitRevision revision = branch.getLatestRevision();
     for (LockDesc lockDesc : lockDescs) {
       final String pathKey = lockDesc.getPath();
@@ -242,5 +245,10 @@ public class LocalLockManager implements LockStorage {
   @NotNull
   private static String createLockId() {
     return UUID.randomUUID().toString();
+  }
+
+  @NotNull
+  public SortedMap<String, LockDesc> getLocks() {
+    return locks;
   }
 }

--- a/src/main/java/svnserver/repository/locks/LockStorage.java
+++ b/src/main/java/svnserver/repository/locks/LockStorage.java
@@ -41,7 +41,7 @@ public interface LockStorage {
 
   boolean cleanupInvalidLocks(@NotNull GitBranch branch) throws IOException;
 
-  void renewLocks(@NotNull GitBranch branch, @NotNull LockDesc[] lockDescs) throws IOException;
+  void refreshLocks(@NotNull User user, @NotNull GitBranch branch, boolean keepLocks, @NotNull LockDesc[] lockDescs) throws IOException;
 
   @NotNull
   Iterator<LockDesc> getLocks(@NotNull User user, @NotNull GitBranch branch, @NotNull String path, @NotNull Depth depth) throws IOException, SVNException;

--- a/src/test/java/svnserver/SvnTestHelper.java
+++ b/src/test/java/svnserver/SvnTestHelper.java
@@ -123,14 +123,22 @@ public final class SvnTestHelper {
   }
 
   public static void modifyFile(@NotNull SVNRepository repo, @NotNull String filePath, @NotNull String newData, long fileRev) throws SVNException, IOException {
-    modifyFile(repo, filePath, newData.getBytes(StandardCharsets.UTF_8), fileRev);
+    modifyFile(repo, filePath, newData, fileRev, null);
+  }
+
+  public static void modifyFile(@NotNull SVNRepository repo, @NotNull String filePath, @NotNull String newData, long fileRev, @Nullable Map<String, String> locks) throws SVNException, IOException {
+    modifyFile(repo, filePath, newData.getBytes(StandardCharsets.UTF_8), fileRev, locks);
   }
 
   public static void modifyFile(@NotNull SVNRepository repo, @NotNull String filePath, @NotNull byte[] newData, long fileRev) throws SVNException, IOException {
+    modifyFile(repo, filePath, newData, fileRev, null);
+  }
+
+  public static void modifyFile(@NotNull SVNRepository repo, @NotNull String filePath, @NotNull byte[] newData, long fileRev, @Nullable Map<String, String> locks) throws SVNException, IOException {
     final ByteArrayOutputStream oldData = new ByteArrayOutputStream();
     repo.getFile(filePath, fileRev, null, oldData);
 
-    final ISVNEditor editor = repo.getCommitEditor("Modify file: " + filePath, null, false, null);
+    final ISVNEditor editor = repo.getCommitEditor("Modify file: " + filePath, locks, false, null);
     try {
       editor.openRoot(-1);
       int index = 0;


### PR DESCRIPTION
1. Decouple up-to-date and lock checks because they're independent
2. Delete locks in remote LFS if keepLocks=false
3. Provide a better error message when commit is blocked because of lock