### PR TITLE
Stop installing gnome-doc-utils on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           java-version: 11 # Oldest supported version
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install build-essential debhelper fakeroot gnome-doc-utils
+        run: sudo apt-get update && sudo apt-get install build-essential debhelper fakeroot
       - name: Build
         uses: eskatos/gradle-command-action@v1
         with:


### PR DESCRIPTION
We do not use it and it isn't available in Ubuntu 20.04 anymore