### PR TITLE
Add docker image creation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -241,6 +241,28 @@ val distDeb by tasks.registering(Copy::class) {
     into("$buildDir/distributions/debian_debian")
 }
 
+val dockerControl by tasks.registering(Copy::class) {
+    from("$projectDir/src/main/docker")
+    into(file("$buildDir"))
+}
+
+val compileDocker by tasks.registering(Exec::class) {
+    dependsOn(tasks.installDist, dockerControl)
+
+    workingDir = file("$buildDir")
+    executable = "docker"
+    args("build", "-t", "local/git-as-svn:latest", ".")
+}
+
+val distDocker by tasks.registering(Exec::class) {
+    group = "distribution"
+    dependsOn(compileDocker)
+
+    workingDir = file("$buildDir/distributions")
+    executable = "sh"
+    args("-c", "docker image save local/git-as-svn:latest | bzip2 > ${project.name}_${project.version}.docker.tbz2")
+}
+
 tasks.assembleDist {
     dependsOn(distDeb)
 }

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM alpine
+
+EXPOSE 22 3690 8123
+
+COPY ["install/git-as-svn/bin", "/usr/share/git-as-svn/bin"]
+COPY ["install/git-as-svn/lib", "/usr/share/git-as-svn/lib"]
+COPY ["install/git-as-svn/tools/git-as-svn-svnserve", \
+      "install/git-as-svn/tools/git-as-svn-svnserve-tunnel", \
+      "/usr/bin/"]
+COPY ["docker-files", "/"]
+COPY ["docs/asciidoc/examples/config.yml", "/usr/share/git-as-svn/"]
+
+ENV GAS_USER git
+ENV GAS_GROUP git
+
+RUN apk add --no-cache \
+        gettext \
+        openjdk11-jre-headless \
+        openssh \
+        s6 \
+        && \
+    rm /etc/ssh/sshd_config && \
+    ln -s /usr/share/git-as-svn/bin/git-as-svn /usr/bin/. && \
+    addgroup -S $GAS_GROUP && \
+    adduser -S -D -h /data -s /bin/ash -g git-as-svn -G $GAS_GROUP $GAS_USER && \
+    sed -i -e "s/^$GAS_USER:x:/$GAS_USER:*:/g" /etc/passwd
+
+VOLUME ["/data", \
+        "/var/git/repositories", \
+        "/var/git/hooks", \
+        "/var/git/ssh-shadow", \
+        "/var/git/ssh-real", \
+        "/var/git/lfs-objects"]
+
+ENTRYPOINT ["/bin/entrypoint"]

--- a/src/main/docker/docker-files/bin/entrypoint
+++ b/src/main/docker/docker-files/bin/entrypoint
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Fix $GAS_USER
+if [ "$GAS_USER" != "git" ]; then
+    sed -i -e "s/^git\:/^$GAS_USER:/g" /etc/passwd
+    sed -i -e "s/\\([:,]\\)git/\\1$GAS_USER:/g" /etc/group
+fi
+
+# Fix $GAS_GROUP
+if [ "$GAS_GROUP" != "git" ]; then
+    sed -i -e "s/^git\\:/^$GAS_GROUP:/g" /etc/group
+fi
+
+# Fix $UID
+OLD_UID=$(id -u $GAS_USER)
+if [ -n "$UID" ] && [ "$UID" != "$OLD_UID" ]; then
+    sed -i -e "s/^\\($GAS_USER:\\*:\\)$OLD_UID:/\\1$UID:/g" /etc/passwd
+fi
+
+# Fix $GID
+OLD_GID=$(id -g $GAS_GROUP)
+if [ -n "$GID" ] && [ "$GID" != "$OLD_GID" ]; then
+    sed -i -e "s/^\\($GAS_USER:\\*:$UID:\\)$OLD_GID/\\1$GID:/g" /etc/passwd
+    sed -i -e "s/^\\($GAS_GROUP:x:\\)$OLD_GID:/\\1$GID:/g" /etc/group
+fi
+
+exec s6-svscan /etc/s6

--- a/src/main/docker/docker-files/etc/s6/.s6-svscan/finish
+++ b/src/main/docker/docker-files/etc/s6/.s6-svscan/finish
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/src/main/docker/docker-files/etc/s6/git-as-svn/finish
+++ b/src/main/docker/docker-files/etc/s6/git-as-svn/finish
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/src/main/docker/docker-files/etc/s6/git-as-svn/run
+++ b/src/main/docker/docker-files/etc/s6/git-as-svn/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+./setup
+cd /data
+exec s6-setuidgid $GAS_USER git-as-svn -c /data/config.yml

--- a/src/main/docker/docker-files/etc/s6/git-as-svn/setup
+++ b/src/main/docker/docker-files/etc/s6/git-as-svn/setup
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+[ ! -d /data/cache ] && mkdir /data/cache
+[ ! -f /data/config.yml ] && cp /usr/share/git-as-svn/templates/config.yml /data/config.yml
+
+chown -R $GAS_USER:$GAS_GROUP /data/
+
+[ '0' = "$(stat -c '%u' /var/git/repositories)" ] && chown $GAS_USER:$GAS_GROUP /var/git/repositories
+[ '0' = "$(stat -c '%u' /var/git/hooks)"        ] && chown $GAS_USER:$GAS_GROUP /var/git/hooks
+[ '0' = "$(stat -c '%u' /var/git/lfs-objects)"  ] && chown $GAS_USER:$GAS_GROUP /var/git/lfs-objects
+[ '0' = "$(stat -c '%u' /var/git/ssh-real)"     ] && chown $GAS_USER:$GAS_GROUP /var/git/ssh-real

--- a/src/main/docker/docker-files/etc/s6/sshd/finish
+++ b/src/main/docker/docker-files/etc/s6/sshd/finish
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/src/main/docker/docker-files/etc/s6/sshd/run
+++ b/src/main/docker/docker-files/etc/s6/sshd/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+./setup
+exec /usr/sbin/sshd -D -e

--- a/src/main/docker/docker-files/etc/s6/sshd/setup
+++ b/src/main/docker/docker-files/etc/s6/sshd/setup
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+[ ! -d /data/ssh ] && mkdir -p /data/ssh
+[ ! -f /data/ssh/ssh_host_ed25519_key ] && \
+    ssh-keygen -t ed25519 -f /data/ssh/ssh_host_ed25519_key -N "" >/dev/null
+
+[ ! -f /data/ssh/ssh_host_ecdsa_key ] && \
+    ssh-keygen -t ecdsa -f /data/ssh/ssh_host_ecdsa_key -N "" >/dev/null
+
+[ ! -f /data/ssh/ssh_host_rsa_key ] && \
+    ssh-keygen -t rsa -f /data/ssh/ssh_host_rsa_key -N "" >/dev/null
+
+if [ ! -f /etc/ssh/sshd_config ]; then
+    SSH_PORT=${SSH_PORT:-"22"} \
+    envsubst < /usr/share/git-as-svn/templates/sshd_config.tmpl > /etc/ssh/sshd_config
+
+    chmod 644 /etc/ssh/sshd_config
+fi
+
+chown root:root /data/ssh/*
+chmod 700 /data/ssh
+chmod 600 /data/ssh/*

--- a/src/main/docker/docker-files/usr/share/git-as-svn/templates/config.yml
+++ b/src/main/docker/docker-files/usr/share/git-as-svn/templates/config.yml
@@ -1,0 +1,119 @@
+!config:
+
+# Specifies IP to listen to for svn:// connections
+# Default: 0.0.0.0
+#
+# host: 0.0.0.0
+
+# Specifies port number to listen to for svn:// connections
+# Default: 3690
+#
+# port: 3690
+
+# Subversion realm name. Subversion uses this for credentials caching
+# Default: git-as-svn realm
+#
+# realm: git-as-svn realm
+
+# Traffic compression level. Supported values: LZ4, Zlib, None
+# Default: LZ4
+#
+# compressionLevel: LZ4
+
+# If enabled, git-as-svn indexed repositories in parallel during startup
+# This results in higher memory usage so may require adjustments to JVM memory options
+# Default: true
+#
+# parallelIndexing: true
+
+# Sets cache location
+cacheConfig: !persistentCache
+  path: /data/cache/git-as-svn.mapdb
+
+# Other available repository mappings: !giteaMapping, !gitlabMapping
+repositoryMapping: !listMapping
+  groups:
+    developers:
+      - test
+  repositories:
+    example:
+      access:
+        /:
+          # Asterisk (*) means all users
+          # $authenticated means authenticated users
+          # $anonymous means anonymous users
+          #
+          # Supported modes: r/rw/none. Empty string also means none
+          '*': r
+          '@developers': rw
+      repository:
+        # Allowed create modes:
+        # - ERROR - exit with error, if repository not exists
+        # - EMPTY - create empty repository
+        # - EXAMPLE - create repository with example data
+        createMode: EXAMPLE
+        branches:
+          - master
+        path: /var/git/repositories/example.git
+        renameDetection: true
+
+shared:
+  # Submodule list.
+  # You can define extra submodule path. Every path defined in "repositories" already included in submodule list.
+  - !submodules [
+  ]
+
+  # git-as-svn builtin web server
+  # It is used for GitLab system hook for repository creation/deletion notifications
+  # Also, git-as-svn builtin LFS server is served through it
+  - !web
+
+    # git-as-svn base url. Leave empty for autodetect.
+    # Default: empty
+    #
+    # baseUrl: http://localhost:8123/
+
+    listen:
+      - !http {
+
+        # The network interface where git-as-svn web server binds to as an IP address or a hostname.  If 0.0.0.0, then bind to all interfaces.
+        # Default: localhost
+        #
+        # host: localhost
+
+        # Port where git-as-svn web server listens on.
+        # Default: 8123
+        #
+        # port: 8123
+
+        # HTTP idle timeout milliseconds. If not a single byte is sent or received over HTTP connection, git-as-svn closes it.
+        # -1 = Use Jetty default
+        # 0 = Disable timeout
+        # Default: -1
+        #
+        # idleTimeout: -1
+
+        # Tells git-as-svn to handle X-Forwarded-* headers.
+        # Enable this if git-as-svn web server is running behind reverse HTTP proxy (like nginx)
+        # Default: false
+        #
+        # forwarded: false
+      }
+
+  # Git LFS server
+  - !localLfs
+    # Secret token for git-lfs-authenticate script
+    # secretToken:
+    path: /var/git/lfs
+
+# Other available userDBs: !ldapUsers !giteaUsers, !gitlabUsers
+# Simple in-memory user database
+userDB: !localUsers
+  users:
+    - username: test
+      # Clear-text password is required to perform CRAM-MD5 authentication
+      password: test
+      # Email and real name are used to create Git commits
+      email: test@noreply.fake
+      realName: Test User
+

--- a/src/main/docker/docker-files/usr/share/git-as-svn/templates/sshd_config.tmpl
+++ b/src/main/docker/docker-files/usr/share/git-as-svn/templates/sshd_config.tmpl
@@ -1,0 +1,34 @@
+Port ${SSH_PORT}
+Protocol 2
+
+HostKey /data/ssh/ssh_host_rsa_key
+HostKey /data/ssh/ssh_host_ecdsa_key
+HostKey /data/ssh/ssh_host_ed25519_key
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+PermitRootLogin no
+#MaxAuthTries 6
+#MaxSessions 10
+
+PubkeyAuthentication yes
+
+AuthorizedKeysFile	.ssh/authorized_keys
+
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+
+AllowAgentForwarding no
+AllowTcpForwarding no
+PrintMotd no
+PermitTTY no
+PermitUserEnvironment no
+UseDNS no
+
+# no default banner path
+Banner none
+
+# override default of no subsystems
+Subsystem	sftp	/usr/lib/ssh/sftp-server

--- a/src/main/kotlin/svnserver/repository/git/prop/GitTortoiseFactory.kt
+++ b/src/main/kotlin/svnserver/repository/git/prop/GitTortoiseFactory.kt
@@ -1,3 +1,10 @@
+/*
+ * This file is part of git-as-svn. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/gpl-2.0.html. No part of git-as-svn,
+ * including this file, may be copied, modified, propagated, or distributed
+ * except according to the terms contained in the LICENSE file.
+ */
 package svnserver.repository.git.prop
 
 import java.io.IOException


### PR DESCRIPTION
It would be advantageous for several reasons (security, dev-ops deploy-ability, environment segregation), to have git-as-svn running inside docker.

I've been playing around with docker and gradle to generate a docker image. I've got it to the point where I think it would be useful for others, although I'd still consider it a WIP for now.