### PR TITLE
Fix exception by making String nullable and adding non-null assertion

### DIFF
--- a/src/main/kotlin/svnserver/repository/git/push/GitPushEmbedded.kt
+++ b/src/main/kotlin/svnserver/repository/git/push/GitPushEmbedded.kt
@@ -152,8 +152,8 @@ class GitPushEmbedded constructor(private val context: LocalContext, private val
 
     private fun getHooksPath(repository: Repository): String {
         if (!Strings.isNullOrEmpty(hooksPathOverride)) return (hooksPathOverride)!!
-        val hooksPathFromConfig: String = repository.config.getString(ConfigConstants.CONFIG_CORE_SECTION, null, "hooksPath")
-        if (!Strings.isNullOrEmpty(hooksPathFromConfig)) return hooksPathFromConfig
+        val hooksPathFromConfig: String? = repository.config.getString(ConfigConstants.CONFIG_CORE_SECTION, null, "hooksPath")
+        if (!Strings.isNullOrEmpty(hooksPathFromConfig)) return hooksPathFromConfig!!
         return "hooks"
     }
 


### PR DESCRIPTION
Exception fixed:
java.lang.NullPointerException: repository.config.getStr…CTION, null, "hooksPath") must not be null
        at svnserver.repository.git.push.GitPushEmbedded.getHooksPath(GitPushEmbedded.kt:155) ~[git-as-svn.jar:?]

Bugs fixed:
Uploading from svn to git-as-svn throws the exception with Gitea setup